### PR TITLE
Integrate judge evaluation for project proposals

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,6 +547,14 @@ function updateStatImages() {
         removeRemotePlayer(msg.id);
       } else if (msg.type === 'addInstitution') {
         createInstitution(msg.institution, true);
+      } else if (msg.type === 'updateInstitution') {
+        const inst = institutionDataMap[msg.id];
+        if (inst) {
+          inst.extraEffects = msg.extraEffects || inst.extraEffects || {};
+          if (inst.owner === playerEmail && msg.gains) {
+            ownedInstitutions.push(msg.gains);
+          }
+        }
       } else if (msg.type === 'money') {
         playerMoney = msg.money;
         updateMoneyDisplay();
@@ -639,12 +647,13 @@ function updateStatImages() {
       obj.rotation.y = inst.rotation || 0;
       scene.add(obj);
       institutionsMap[inst.id] = obj;
-      institutionDataMap[inst.id] = { ...inst, effects: def.effects, workforce: inst.workforce || [] };
+      institutionDataMap[inst.id] = { ...inst, effects: def.effects, workforce: inst.workforce || [], extraEffects: inst.extraEffects || {}};
       obj.traverse(o => { o.userData.institutionId = inst.id; });
       const box = new THREE.Box3().setFromObject(obj);
       institutionBoxes.push({ id: inst.id, box });
-      if (inst.owner === playerEmail && def.effects) {
-        ownedInstitutions.push(def.effects);
+      if (inst.owner === playerEmail) {
+        if (def.effects) ownedInstitutions.push(def.effects);
+        if (inst.extraEffects) ownedInstitutions.push(inst.extraEffects);
       }
       if (animate) {
         const startY = obj.position.y + 5;
@@ -679,7 +688,12 @@ function updateStatImages() {
     Object.values(institutionDataMap).forEach(d => {
       if (d.owner === instData.owner && d.name === instData.name) count++;
     });
-    const effects = def.effects || {};
+    const effects = Object.assign({}, def.effects || {});
+    if (instData.extraEffects) {
+      for (const k of Object.keys(instData.extraEffects)) {
+        effects[k] = (effects[k] || 0) + instData.extraEffects[k];
+      }
+    }
     const lines = [];
     Object.keys(effects).forEach(k => {
       lines.push(`${k}: +${effects[k]} (${(effects[k]*count).toFixed(2)} total)`);

--- a/institutionStore.js
+++ b/institutionStore.js
@@ -30,6 +30,9 @@ function addInstitution(inst) {
   inst.id = data.nextId++;
   if (!inst.workforce) inst.workforce = [];
   if (!inst.proposals) inst.proposals = [];
+  if (!inst.extraEffects) {
+    inst.extraEffects = { hydration: 0, oxygen: 0, health: 0, money: 0 };
+  }
   data.list.push(inst);
   saveData(data);
   return inst.id;
@@ -88,6 +91,22 @@ function updateProposal(instId, index, updates) {
   return proposal;
 }
 
+function addGains(instId, gains) {
+  const data = loadData();
+  const inst = data.list.find(i => i.id === instId);
+  if (!inst) return null;
+  if (!inst.extraEffects) {
+    inst.extraEffects = { hydration: 0, oxygen: 0, health: 0, money: 0 };
+  }
+  for (const key of ['hydration', 'oxygen', 'health', 'money']) {
+    if (gains && typeof gains[key] === 'number') {
+      inst.extraEffects[key] += gains[key];
+    }
+  }
+  saveData(data);
+  return inst.extraEffects;
+}
+
 module.exports = {
   getInstitutions,
   addInstitution,
@@ -97,4 +116,5 @@ module.exports = {
   addProposal,
   getProposals,
   updateProposal,
+  addGains,
 };

--- a/judge.js
+++ b/judge.js
@@ -1,0 +1,36 @@
+const OpenAI = require('openai');
+let openai = null;
+try {
+  if (process.env.OPENAI_API_KEY) {
+    openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  }
+} catch {}
+
+async function judgeProposal(proposal, ecosystem) {
+  if (!openai) {
+    // simple fallback: return given gains or null if none
+    return { feasible: true, gains: proposal.gains || null };
+  }
+  const messages = [
+    { role: 'system', content: 'You are a strict project feasibility judge for a Mars colony. Reply only in JSON.' },
+    { role: 'user', content: JSON.stringify({ ecosystem, proposal }) }
+  ];
+  try {
+    const response = await openai.chat.completions.create({
+      model: 'gpt-4.1',
+      messages,
+      response_format: { type: 'json_object' },
+      temperature: 1,
+      max_completion_tokens: 2048,
+      top_p: 1,
+      frequency_penalty: 0,
+      presence_penalty: 0
+    });
+    const text = response?.choices?.[0]?.message?.content || '';
+    return JSON.parse(text);
+  } catch {
+    return { feasible: false, gains: null };
+  }
+}
+
+module.exports = { judgeProposal };

--- a/proposals.js
+++ b/proposals.js
@@ -87,11 +87,24 @@ export function renderProposals(container, proposals, instId, institutionDataMap
     }
 
     approve.onclick = async () => {
-      await fetch(`/api/workforce/proposals/${instId}`, {
+      const res = await fetch(`/api/workforce/proposals/${instId}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ index: idx, approve: true })
       });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.result && data.result.gains) {
+          const inst = institutionDataMap[instId];
+          if (inst) {
+            inst.extraEffects = inst.extraEffects || {};
+            Object.assign(inst.extraEffects, data.result.gains);
+            if (inst.owner === playerEmail) {
+              ownedInstitutions.push(data.result.gains);
+            }
+          }
+        }
+      }
       card.remove();
     };
 

--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ const INSTITUTION_PRICES = {
 const loginRoute = require('./api/login')(client, verifySid);
 const verifyRoute = require('./api/verify')(client, verifySid, userStore);
 const stateRoute = require('./api/state')(userStore);
-const workforceRoute = require('./api/workforce')(institutionStore, userStore);
+const workforceRoute = require('./api/workforce')(institutionStore, userStore, engine, broadcast);
 chatManager.initFromInstitutions(institutionStore.getInstitutions());
 
 app.use('/api/login', loginRoute);
@@ -184,8 +184,8 @@ wss.on('connection', (ws, req) => {
             scale: data.scale
           };
           const instId = institutionStore.addInstitution(inst);
-          inst.id = instId;
-          broadcast({ type: 'addInstitution', institution: inst });
+          const storedInst = institutionStore.getInstitution(instId);
+          broadcast({ type: 'addInstitution', institution: storedInst });
           if (ws.readyState === WebSocket.OPEN) {
             ws.send(JSON.stringify({ type: 'money', money: user.money }));
           }


### PR DESCRIPTION
## Summary
- add `judge.js` for GPT-based feasibility checks
- track extra institution effects in `institutionStore`
- broadcast new institution updates via WebSocket
- evaluate proposals via judge in workforce API
- handle updates and extra gains client side

## Testing
- `npm test` *(fails: Missing script)*