### PR TITLE
Add proposal history tracking and judge feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,9 +919,11 @@ function updateStatImages() {
       container.innerHTML = '<div class="spinner" style="height:100px;color:#fff">Loading...</div>';
       try {
         const res = await fetch(`/api/workforce/proposals/${id}`);
-        if (res.ok) {
+        const hist = await fetch(`/api/workforce/proposals/history/${id}`);
+        if (res.ok && hist.ok) {
           const data = await res.json();
-          renderProposals(container, data.proposals || [], id, institutionDataMap, playerEmail);
+          const h = await hist.json();
+          renderProposals(container, data.proposals || [], id, institutionDataMap, playerEmail, h.history || []);
         }
       } catch(err){
         container.innerHTML = '<div style="color:#ff6666">Failed</div>';

--- a/institutionStore.js
+++ b/institutionStore.js
@@ -30,6 +30,7 @@ function addInstitution(inst) {
   inst.id = data.nextId++;
   if (!inst.workforce) inst.workforce = [];
   if (!inst.proposals) inst.proposals = [];
+  if (!inst.proposalHistory) inst.proposalHistory = [];
   if (!inst.extraEffects) {
     inst.extraEffects = { hydration: 0, oxygen: 0, health: 0, money: 0 };
   }
@@ -56,6 +57,7 @@ function addProposal(instId, proposal) {
   const data = loadData();
   const inst = data.list.find(i => i.id === instId);
   if (!inst) return null;
+  if (!Array.isArray(inst.proposalHistory)) inst.proposalHistory = [];
   const full = {
     project: proposal.project || proposal.title || 'Project',
     description: proposal.description || '',
@@ -77,12 +79,21 @@ function getProposals(instId) {
   return inst.proposals.filter(p => p.status === 'pending');
 }
 
+function getProposalHistory(instId) {
+  const data = loadData();
+  const inst = data.list.find(i => i.id === instId);
+  if (!inst || !Array.isArray(inst.proposalHistory)) return [];
+  return inst.proposalHistory;
+}
+
 function updateProposal(instId, index, updates) {
   const data = loadData();
   const inst = data.list.find(i => i.id === instId);
   if (!inst || !inst.proposals || !inst.proposals[index]) return null;
   const proposal = Object.assign({}, inst.proposals[index], updates);
+  if (!Array.isArray(inst.proposalHistory)) inst.proposalHistory = [];
   if (proposal.status !== 'pending') {
+    inst.proposalHistory.push(proposal);
     inst.proposals.splice(index, 1);
   } else {
     inst.proposals[index] = proposal;
@@ -115,6 +126,7 @@ module.exports = {
   findInstitution,
   addProposal,
   getProposals,
+  getProposalHistory,
   updateProposal,
   addGains,
 };

--- a/proposals.js
+++ b/proposals.js
@@ -11,14 +11,13 @@ export function checkPrerequisite(pr, playerEmail, institutionDataMap) {
   return false;
 }
 
-export function renderProposals(container, proposals, instId, institutionDataMap, playerEmail) {
+export function renderProposals(container, proposals, instId, institutionDataMap, playerEmail, history = []) {
   container.innerHTML = '';
   if (!proposals || proposals.length === 0) {
     container.innerHTML = '<div style="color:#fff">No proposals</div>';
-    return;
-  }
+  } else {
 
-  proposals.forEach((p, idx) => {
+    proposals.forEach((p, idx) => {
     const card = document.createElement('div');
     card.style.border = '1px solid #888';
     card.style.padding = '8px';
@@ -121,4 +120,32 @@ export function renderProposals(container, proposals, instId, institutionDataMap
     card.appendChild(deny);
     container.appendChild(card);
   });
+  }
+
+  if (history && history.length > 0) {
+    const header = document.createElement('div');
+    header.style.marginTop = '10px';
+    header.style.color = '#fff';
+    header.textContent = 'Past Proposals';
+    container.appendChild(header);
+    history.forEach(p => {
+      const card = document.createElement('div');
+      card.style.border = '1px solid #444';
+      card.style.padding = '6px';
+      card.style.marginBottom = '4px';
+      const title = document.createElement('div');
+      title.textContent = p.project;
+      title.style.fontWeight = 'bold';
+      card.appendChild(title);
+      const status = document.createElement('div');
+      status.textContent = `Status: ${p.status}`;
+      card.appendChild(status);
+      if (p.judgeResult && !p.judgeResult.feasible) {
+        const note = document.createElement('div');
+        note.textContent = p.judgeResult.gains;
+        card.appendChild(note);
+      }
+      container.appendChild(card);
+    });
+  }
 }

--- a/workforceChatManager.js
+++ b/workforceChatManager.js
@@ -185,7 +185,7 @@ class WorkforceChatManager {
     this._save();
   }
 
-  resolveProposal(instId, index, status) {
+  resolveProposal(instId, index, status, note = null) {
     const inst = institutionStore.getInstitution(instId);
     if (!inst) return;
     const key = this._key(inst.owner, inst.name);
@@ -193,7 +193,9 @@ class WorkforceChatManager {
     if (!chat) return;
     if (chat.pendingProposal && chat.pendingProposal.instId === instId && chat.pendingProposal.index === index) {
       chat.pendingProposal = null;
-      chat.messages.push({ worker: 'System', text: `Proposal ${status}` });
+      let msg = `Proposal ${status}`;
+      if (note) msg += `: ${note}`;
+      chat.messages.push({ worker: 'System', text: msg });
       this._save();
     }
   }


### PR DESCRIPTION
## Summary
- track `proposalHistory` for institutions
- save judge results and show them in chat via `resolveProposal`
- expose proposal history endpoints and update proposal workflow
- display past proposals in the UI

## Testing
- `npm test` *(fails: Missing script)*