### PR TITLE
Add scaffold+Meshy generation workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,6 +522,7 @@ function updateStatImages() {
   const institutionDataMap = {};
   const institutionBoxes = [];
   const sinking = [];
+  const constructionMap = {};
 
   function initNetwork() {
     socket = new WebSocket('ws://localhost:3000?email=' + encodeURIComponent(playerEmail));
@@ -553,6 +554,10 @@ function updateStatImages() {
         const inst = institutionDataMap[msg.id];
         if (inst) {
           inst.extraEffects = msg.extraEffects || inst.extraEffects || {};
+          if (msg.construction !== undefined) {
+            inst.construction = msg.construction;
+            applyConstruction(inst);
+          }
           if (inst.owner === playerEmail && msg.gains) {
             ownedInstitutions.push(msg.gains);
           }
@@ -638,6 +643,27 @@ function updateStatImages() {
     delete remotePlayers[id];
   }
 
+  function applyConstruction(inst) {
+    const existing = constructionMap[inst.id] || {};
+    if (existing.scaff) scene.remove(existing.scaff);
+    if (existing.final) scene.remove(existing.final);
+    constructionMap[inst.id] = {};
+    if (!inst.construction) return;
+    const loader = new GLTFLoader();
+    loader.load(inst.construction.url, gltf => {
+      const obj = gltf.scene;
+      obj.position.fromArray(inst.position);
+      obj.rotation.y = inst.rotation || 0;
+      obj.scale.setScalar(inst.construction.scale || inst.scale || 1);
+      scene.add(obj);
+      if (inst.construction.status === 'scaffolding') {
+        constructionMap[inst.id].scaff = obj;
+      } else {
+        constructionMap[inst.id].final = obj;
+      }
+    });
+  }
+
   function createInstitution(inst, animate) {
     const def = institutions.find(i => i.name === inst.name);
     if (!def) return;
@@ -653,6 +679,7 @@ function updateStatImages() {
       obj.traverse(o => { o.userData.institutionId = inst.id; });
       const box = new THREE.Box3().setFromObject(obj);
       institutionBoxes.push({ id: inst.id, box });
+      applyConstruction(institutionDataMap[inst.id]);
       if (inst.owner === playerEmail) {
         if (def.effects) ownedInstitutions.push(def.effects);
         if (inst.extraEffects) ownedInstitutions.push(inst.extraEffects);

--- a/institutionStore.js
+++ b/institutionStore.js
@@ -34,6 +34,7 @@ function addInstitution(inst) {
   if (!inst.extraEffects) {
     inst.extraEffects = { hydration: 0, oxygen: 0, health: 0, money: 0 };
   }
+  if (!inst.construction) inst.construction = null;
   data.list.push(inst);
   saveData(data);
   return inst.id;

--- a/meshy.js
+++ b/meshy.js
@@ -1,0 +1,52 @@
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+
+const API_BASE = 'https://api.meshy.ai/openapi/v2';
+
+function headers() {
+  const key = process.env.MESHY_API_KEY || '';
+  return { Authorization: `Bearer ${key}` };
+}
+
+async function createPreview(prompt) {
+  const payload = {
+    mode: 'preview',
+    prompt,
+    art_style: 'realistic',
+    should_remesh: true
+  };
+  const { data } = await axios.post(`${API_BASE}/text-to-3d`, payload, { headers: headers() });
+  return data.result;
+}
+
+async function pollTask(id) {
+  while (true) {
+    const { data } = await axios.get(`${API_BASE}/text-to-3d/${id}`, { headers: headers() });
+    if (data.status === 'SUCCEEDED') return data;
+    await new Promise(r => setTimeout(r, 5000));
+  }
+}
+
+async function createRefine(previewId) {
+  const payload = { mode: 'refine', preview_task_id: previewId };
+  const { data } = await axios.post(`${API_BASE}/text-to-3d`, payload, { headers: headers() });
+  return data.result;
+}
+
+async function download(url, filePath) {
+  const res = await axios.get(url, { responseType: 'arraybuffer' });
+  fs.writeFileSync(filePath, res.data);
+}
+
+async function generateModel(prompt, filePath) {
+  const previewId = await createPreview(prompt);
+  await pollTask(previewId);
+  const refineId = await createRefine(previewId);
+  const refineTask = await pollTask(refineId);
+  const glbUrl = refineTask.model_urls.glb;
+  await download(glbUrl, filePath);
+  return filePath;
+}
+
+module.exports = { generateModel };


### PR DESCRIPTION
## Summary
- add Meshy API client
- store construction info in institution data
- trigger scaffolding and Meshy job when a proposal is approved
- handle construction models on the frontend
- keep generated models under `generated_models/`

## Testing
- `npm test` *(fails: Missing script)*