### PR TITLE
Add random construction placement with collision

### DIFF
--- a/api/workforce.js
+++ b/api/workforce.js
@@ -340,7 +340,15 @@ module.exports = function(institutionStore, userStore, engine, broadcast) {
         }
         if (result && result.feasible) {
           const scaff = SCAFF_MODELS[Math.floor(Math.random() * SCAFF_MODELS.length)];
-          const construction = { status: 'scaffolding', url: scaff.url, scale: scaff.scale };
+          const angle = Math.random() * Math.PI * 2;
+          const distance = 8 + Math.random() * 4;
+          const offset = [Math.cos(angle) * distance, 0, Math.sin(angle) * distance];
+          const construction = {
+            status: 'scaffolding',
+            url: scaff.url,
+            scale: scaff.scale,
+            offset
+          };
           institutionStore.updateInstitution(id, { construction });
           broadcast({ type: 'updateInstitution', id, construction });
 
@@ -349,7 +357,12 @@ module.exports = function(institutionStore, userStore, engine, broadcast) {
           meshy.generateModel(prompt, file)
             .then(fp => {
               const rel = path.relative(path.join(__dirname, '..'), fp).replace(/\\/g, '/');
-              const done = { status: 'completed', url: rel, scale: scaff.scale };
+              const done = {
+                status: 'completed',
+                url: rel,
+                scale: scaff.scale,
+                offset
+              };
               institutionStore.updateInstitution(id, { construction: done });
               broadcast({ type: 'updateInstitution', id, construction: done });
             })

--- a/index.html
+++ b/index.html
@@ -521,6 +521,7 @@ function updateStatImages() {
   const institutionsMap = {};
   const institutionDataMap = {};
   const institutionBoxes = [];
+  const constructionBoxes = [];
   const sinking = [];
   const constructionMap = {};
 
@@ -643,32 +644,52 @@ function updateStatImages() {
     delete remotePlayers[id];
   }
 
+  function removeConstructionBoxes(id) {
+    for (let i = constructionBoxes.length - 1; i >= 0; i--) {
+      if (constructionBoxes[i].id === id) constructionBoxes.splice(i, 1);
+    }
+  }
+
   function applyConstruction(inst) {
     const existing = constructionMap[inst.id] || {};
     if (existing.scaff) scene.remove(existing.scaff);
     if (existing.final) scene.remove(existing.final);
+    removeConstructionBoxes(inst.id);
     constructionMap[inst.id] = {};
     if (!inst.construction) return;
     const loader = new GLTFLoader();
     loader.load(inst.construction.url, gltf => {
       const obj = gltf.scene;
+      const offset = Array.isArray(inst.construction.offset)
+        ? new THREE.Vector3().fromArray(inst.construction.offset)
+        : null;
       let pos = new THREE.Vector3().fromArray(inst.position);
-      const boxEntry = institutionBoxes.find(b => b.id === inst.id);
-      if (boxEntry) {
-        const size = new THREE.Vector3();
-        boxEntry.box.getSize(size);
-        const offset = new THREE.Vector3(size.x / 2 + 3, 0, 0);
-        offset.applyAxisAngle(new THREE.Vector3(0, 1, 0), inst.rotation || 0);
+      if (offset) {
         pos.add(offset);
-        console.log('Applying construction for', inst.id, 'offset', offset);
       } else {
-        pos.x += 3; // default offset
-        console.log('Applying construction for', inst.id, 'default offset');
+        const boxEntry = institutionBoxes.find(b => b.id === inst.id);
+        if (boxEntry) {
+          const size = new THREE.Vector3();
+          boxEntry.box.getSize(size);
+          const off = new THREE.Vector3(size.x / 2 + 3, 0, 0);
+          off.applyAxisAngle(new THREE.Vector3(0, 1, 0), inst.rotation || 0);
+          pos.add(off);
+        } else {
+          pos.x += 3;
+        }
       }
-      obj.position.copy(pos);
-      obj.rotation.y = inst.rotation || 0;
+
       obj.scale.setScalar(inst.construction.scale || inst.scale || 1);
+      obj.rotation.y = inst.rotation || 0;
       scene.add(obj);
+      // ensure bottom on terrain
+      const box = new THREE.Box3().setFromObject(obj);
+      const ground = getGroundHeightAt(pos.x, pos.z);
+      obj.position.set(pos.x, ground - box.min.y, pos.z);
+
+      const cbox = new THREE.Box3().setFromObject(obj);
+      constructionBoxes.push({ id: inst.id, box: cbox });
+
       if (inst.construction.status === 'scaffolding') {
         constructionMap[inst.id].scaff = obj;
       } else {
@@ -1038,6 +1059,14 @@ function updateStatImages() {
   function updateInstitutionBoxes() {
     institutionBoxes.forEach(entry => {
       const obj = institutionsMap[entry.id];
+      if (obj) entry.box.setFromObject(obj);
+    });
+  }
+
+  function updateConstructionBoxes() {
+    constructionBoxes.forEach(entry => {
+      const c = constructionMap[entry.id];
+      const obj = c && (c.scaff || c.final);
       if (obj) entry.box.setFromObject(obj);
     });
   }
@@ -1821,6 +1850,7 @@ function updateStatImages() {
     updateParticles(dt);
     updateSinking(dt);
     updateInstitutionBoxes();
+    updateConstructionBoxes();
 
     if (mixer) mixer.update(dt);
     for (const id in remotePlayers) {
@@ -1895,6 +1925,9 @@ function updateStatImages() {
                 let blocked = false;
                 const sphere = new THREE.Sphere(proposed, 1);
                 institutionBoxes.forEach(entry => {
+                    if (entry.box.intersectsSphere(sphere)) blocked = true;
+                });
+                constructionBoxes.forEach(entry => {
                     if (entry.box.intersectsSphere(sphere)) blocked = true;
                 });
                 if (!blocked) {


### PR DESCRIPTION
## Summary
- place construction scaffolding with random offset around institution
- use the same offset when replacing scaffold with final meshy model
- track construction boxes so players collide with scaffolding and new models
- keep objects aligned with the ground

## Testing
- `npm test` *(fails: Missing script)*