### PR TITLE
Fix persistent constructions from multiple proposals

### DIFF
--- a/api/workforce.js
+++ b/api/workforce.js
@@ -349,8 +349,8 @@ module.exports = function(institutionStore, userStore, engine, broadcast) {
             scale: scaff.scale,
             offset
           };
-          institutionStore.updateInstitution(id, { construction });
-          broadcast({ type: 'updateInstitution', id, construction });
+          const idx = institutionStore.addConstruction(id, construction);
+          broadcast({ type: 'updateInstitution', id, construction, index: idx });
 
           const prompt = `${orig.project || orig.title || ''} ${orig.description || ''}`.trim();
           const file = path.join(MODEL_DIR, `inst_${id}_${Date.now()}.glb`);
@@ -363,8 +363,8 @@ module.exports = function(institutionStore, userStore, engine, broadcast) {
                 scale: scaff.scale,
                 offset
               };
-              institutionStore.updateInstitution(id, { construction: done });
-              broadcast({ type: 'updateInstitution', id, construction: done });
+              institutionStore.updateConstruction(id, idx, done);
+              broadcast({ type: 'updateInstitution', id, construction: done, index: idx });
             })
             .catch(err => console.error('Meshy generation failed:', err));
         }

--- a/index.html
+++ b/index.html
@@ -523,7 +523,7 @@ function updateStatImages() {
   const institutionBoxes = [];
   const constructionBoxes = [];
   const sinking = [];
-  const constructionMap = {};
+  const constructionMap = {}; // id -> array of {scaff, final}
 
   function initNetwork() {
     socket = new WebSocket('ws://localhost:3000?email=' + encodeURIComponent(playerEmail));
@@ -556,7 +556,8 @@ function updateStatImages() {
         if (inst) {
           inst.extraEffects = msg.extraEffects || inst.extraEffects || {};
           if (msg.construction !== undefined) {
-            inst.construction = msg.construction;
+            if (!Array.isArray(inst.constructions)) inst.constructions = [];
+            inst.constructions[msg.index] = msg.construction;
             applyConstruction(inst);
           }
           if (inst.owner === playerEmail && msg.gains) {
@@ -651,50 +652,55 @@ function updateStatImages() {
   }
 
   function applyConstruction(inst) {
-    const existing = constructionMap[inst.id] || {};
-    if (existing.scaff) scene.remove(existing.scaff);
-    if (existing.final) scene.remove(existing.final);
+    const existing = constructionMap[inst.id] || [];
+    existing.forEach(e => {
+      if (e.scaff) scene.remove(e.scaff);
+      if (e.final) scene.remove(e.final);
+    });
     removeConstructionBoxes(inst.id);
-    constructionMap[inst.id] = {};
-    if (!inst.construction) return;
-    const loader = new GLTFLoader();
-    loader.load(inst.construction.url, gltf => {
-      const obj = gltf.scene;
-      const offset = Array.isArray(inst.construction.offset)
-        ? new THREE.Vector3().fromArray(inst.construction.offset)
-        : null;
-      let pos = new THREE.Vector3().fromArray(inst.position);
-      if (offset) {
-        pos.add(offset);
-      } else {
-        const boxEntry = institutionBoxes.find(b => b.id === inst.id);
-        if (boxEntry) {
-          const size = new THREE.Vector3();
-          boxEntry.box.getSize(size);
-          const off = new THREE.Vector3(size.x / 2 + 3, 0, 0);
-          off.applyAxisAngle(new THREE.Vector3(0, 1, 0), inst.rotation || 0);
-          pos.add(off);
+    constructionMap[inst.id] = [];
+    if (!Array.isArray(inst.constructions)) return;
+    inst.constructions.forEach((c, idx) => {
+      if (!c) return;
+      const loader = new GLTFLoader();
+      loader.load(c.url, gltf => {
+        const obj = gltf.scene;
+        const offset = Array.isArray(c.offset)
+          ? new THREE.Vector3().fromArray(c.offset)
+          : null;
+        let pos = new THREE.Vector3().fromArray(inst.position);
+        if (offset) {
+          pos.add(offset);
         } else {
-          pos.x += 3;
+          const boxEntry = institutionBoxes.find(b => b.id === inst.id);
+          if (boxEntry) {
+            const size = new THREE.Vector3();
+            boxEntry.box.getSize(size);
+            const off = new THREE.Vector3(size.x / 2 + 3, 0, 0);
+            off.applyAxisAngle(new THREE.Vector3(0, 1, 0), inst.rotation || 0);
+            pos.add(off);
+          } else {
+            pos.x += 3;
+          }
         }
-      }
 
-      obj.scale.setScalar(inst.construction.scale || inst.scale || 1);
-      obj.rotation.y = inst.rotation || 0;
-      scene.add(obj);
-      // ensure bottom on terrain
-      const box = new THREE.Box3().setFromObject(obj);
-      const ground = getGroundHeightAt(pos.x, pos.z);
-      obj.position.set(pos.x, ground - box.min.y, pos.z);
+        obj.scale.setScalar(c.scale || inst.scale || 1);
+        obj.rotation.y = inst.rotation || 0;
+        scene.add(obj);
+        const box = new THREE.Box3().setFromObject(obj);
+        const ground = getGroundHeightAt(pos.x, pos.z);
+        obj.position.set(pos.x, ground - box.min.y, pos.z);
 
-      const cbox = new THREE.Box3().setFromObject(obj);
-      constructionBoxes.push({ id: inst.id, box: cbox });
+        const cbox = new THREE.Box3().setFromObject(obj);
+        constructionBoxes.push({ id: inst.id, index: idx, box: cbox });
 
-      if (inst.construction.status === 'scaffolding') {
-        constructionMap[inst.id].scaff = obj;
-      } else {
-        constructionMap[inst.id].final = obj;
-      }
+        if (!constructionMap[inst.id][idx]) constructionMap[inst.id][idx] = {};
+        if (c.status === 'scaffolding') {
+          constructionMap[inst.id][idx].scaff = obj;
+        } else {
+          constructionMap[inst.id][idx].final = obj;
+        }
+      });
     });
   }
 
@@ -709,7 +715,8 @@ function updateStatImages() {
       obj.rotation.y = inst.rotation || 0;
       scene.add(obj);
       institutionsMap[inst.id] = obj;
-      institutionDataMap[inst.id] = { ...inst, effects: def.effects, workforce: inst.workforce || [], extraEffects: inst.extraEffects || {}};
+      const cons = inst.constructions || (inst.construction ? [inst.construction] : []);
+      institutionDataMap[inst.id] = { ...inst, effects: def.effects, workforce: inst.workforce || [], extraEffects: inst.extraEffects || {}, constructions: cons };
       obj.traverse(o => { o.userData.institutionId = inst.id; });
       const box = new THREE.Box3().setFromObject(obj);
       institutionBoxes.push({ id: inst.id, box });
@@ -1065,7 +1072,8 @@ function updateStatImages() {
 
   function updateConstructionBoxes() {
     constructionBoxes.forEach(entry => {
-      const c = constructionMap[entry.id];
+      const list = constructionMap[entry.id];
+      const c = list && list[entry.index];
       const obj = c && (c.scaff || c.final);
       if (obj) entry.box.setFromObject(obj);
     });

--- a/institutionStore.js
+++ b/institutionStore.js
@@ -34,7 +34,7 @@ function addInstitution(inst) {
   if (!inst.extraEffects) {
     inst.extraEffects = { hydration: 0, oxygen: 0, health: 0, money: 0 };
   }
-  if (!inst.construction) inst.construction = null;
+  if (!Array.isArray(inst.constructions)) inst.constructions = [];
   data.list.push(inst);
   saveData(data);
   return inst.id;
@@ -68,9 +68,10 @@ function addProposal(instId, proposal) {
     risk: proposal.risk || null,
     status: 'pending'
   };
-  inst.proposals = [full];
+  if (!Array.isArray(inst.proposals)) inst.proposals = [];
+  inst.proposals.push(full);
   saveData(data);
-  return { proposal: full, index: 0 };
+  return { proposal: full, index: inst.proposals.length - 1 };
 }
 
 function getProposals(instId) {
@@ -103,6 +104,25 @@ function updateProposal(instId, index, updates) {
   return proposal;
 }
 
+function addConstruction(instId, construction) {
+  const data = loadData();
+  const inst = data.list.find(i => i.id === instId);
+  if (!inst) return null;
+  if (!Array.isArray(inst.constructions)) inst.constructions = [];
+  inst.constructions.push(construction);
+  saveData(data);
+  return inst.constructions.length - 1;
+}
+
+function updateConstruction(instId, index, updates) {
+  const data = loadData();
+  const inst = data.list.find(i => i.id === instId);
+  if (!inst || !inst.constructions || !inst.constructions[index]) return null;
+  Object.assign(inst.constructions[index], updates);
+  saveData(data);
+  return inst.constructions[index];
+}
+
 function addGains(instId, gains) {
   const data = loadData();
   const inst = data.list.find(i => i.id === instId);
@@ -129,5 +149,7 @@ module.exports = {
   getProposals,
   getProposalHistory,
   updateProposal,
+  addConstruction,
+  updateConstruction,
   addGains,
 };


### PR DESCRIPTION
## Summary
- allow institutions to track many construction projects
- store multiple proposal entries instead of replacing existing ones
- broadcast construction updates with an index
- render all constructions for an institution in the client

## Testing
- `node --check api/workforce.js`
- `node --check institutionStore.js`