### PR TITLE
Fix placement for construction and weapons

### DIFF
--- a/api/defence.js
+++ b/api/defence.js
@@ -31,12 +31,19 @@ module.exports = function(store, broadcast) {
         const force = p.force || 0;
         const fuel = p.fuel || 0;
         const movement = weight > 0 ? (force / weight) * fuel : 0;
+        function getOffset() {
+          const angle = Math.random() * Math.PI * 2;
+          const distance = 8 + Math.random() * 4;
+          return [Math.cos(angle) * distance, 0, Math.sin(angle) * distance];
+        }
+        const offset = getOffset();
         const weapon = {
           name: prop.name,
           model: SCAFF.url,
           movement,
           status: 'scaffolding',
           scale: SCAFF.scale,
+          offset,
         };
         const wIdx = store.addWeapon(id, weapon);
         broadcast({ type: 'updateWeapon', id, weapon, index: wIdx });

--- a/api/workforce.js
+++ b/api/workforce.js
@@ -340,9 +340,20 @@ module.exports = function(institutionStore, userStore, engine, broadcast) {
         }
         if (result && result.feasible) {
           const scaff = SCAFF_MODELS[Math.floor(Math.random() * SCAFF_MODELS.length)];
-          const angle = Math.random() * Math.PI * 2;
-          const distance = 8 + Math.random() * 4;
-          const offset = [Math.cos(angle) * distance, 0, Math.sin(angle) * distance];
+          const existing = Array.isArray(inst.constructions) ? inst.constructions : [];
+          function getOffset() {
+            const angle = Math.random() * Math.PI * 2;
+            const distance = 8 + Math.random() * 4;
+            return [Math.cos(angle) * distance, 0, Math.sin(angle) * distance];
+          }
+          let offset = getOffset();
+          for (let a = 0; a < 20; a++) {
+            const [ox, , oz] = offset;
+            const ok = !existing.some(c => Array.isArray(c.offset) &&
+              Math.hypot((c.offset[0] || 0) - ox, (c.offset[2] || 0) - oz) < 4);
+            if (ok) break;
+            offset = getOffset();
+          }
           const construction = {
             status: 'scaffolding',
             url: scaff.url,

--- a/index.html
+++ b/index.html
@@ -767,26 +767,29 @@ function updateStatImages() {
           : null;
         let pos = new THREE.Vector3().fromArray(inst.position);
         if (offset) {
+          offset.applyAxisAngle(new THREE.Vector3(0, 1, 0), inst.rotation || 0);
           pos.add(offset);
         } else {
           const boxEntry = institutionBoxes.find(b => b.id === inst.id);
           if (boxEntry) {
             const size = new THREE.Vector3();
             boxEntry.box.getSize(size);
-            const off = new THREE.Vector3(size.x / 2 + 3, 0, 0);
+            const off = new THREE.Vector3(size.x / 2 + 5, 0, 0);
             off.applyAxisAngle(new THREE.Vector3(0, 1, 0), inst.rotation || 0);
             pos.add(off);
           } else {
-            pos.x += 3;
+            pos.x += 5;
           }
         }
 
         obj.scale.setScalar(c.scale || inst.scale || 1);
         obj.rotation.y = inst.rotation || 0;
         scene.add(obj);
-        const box = new THREE.Box3().setFromObject(obj);
+        const boxTmp = new THREE.Box3().setFromObject(obj);
+        const radius = Math.max(boxTmp.max.x - boxTmp.min.x, boxTmp.max.z - boxTmp.min.z) * 0.6;
         const ground = getGroundHeightAt(pos.x, pos.z);
-        obj.position.set(pos.x, ground - box.min.y, pos.z);
+        flattenTerrain(pos.x, pos.z, radius, ground);
+        obj.position.set(pos.x, ground - boxTmp.min.y, pos.z);
 
         const cbox = new THREE.Box3().setFromObject(obj);
         constructionBoxes.push({ id: inst.id, index: idx, box: cbox });
@@ -811,16 +814,23 @@ function updateStatImages() {
       const loader = new GLTFLoader();
       loader.load(w.model, gltf => {
         const obj = gltf.scene;
-        let pos = new THREE.Vector3().fromArray(inst.position);
-        pos.x += 4 + idx * 2;
-        const ground = getGroundHeightAt(pos.x, pos.z);
-        obj.position.set(pos.x, ground, pos.z);
+        const offset = Array.isArray(w.offset)
+          ? new THREE.Vector3().fromArray(w.offset)
+          : new THREE.Vector3(6 + idx * 2, 0, 0);
+        offset.applyAxisAngle(new THREE.Vector3(0, 1, 0), inst.rotation || 0);
+        const pos = new THREE.Vector3().fromArray(inst.position).add(offset);
         obj.scale.setScalar(w.scale || 1);
+        obj.rotation.y = inst.rotation || 0;
+        scene.add(obj);
+        const boxTmp = new THREE.Box3().setFromObject(obj);
+        const radius = Math.max(boxTmp.max.x - boxTmp.min.x, boxTmp.max.z - boxTmp.min.z) * 0.6;
+        const ground = getGroundHeightAt(pos.x, pos.z);
+        flattenTerrain(pos.x, pos.z, radius, ground);
+        obj.position.set(pos.x, ground - boxTmp.min.y, pos.z);
         obj.traverse(o => {
           o.userData.weaponInstId = inst.id;
           o.userData.weaponIndex = idx;
         });
-        scene.add(obj);
         weaponMap[inst.id][idx] = { obj, data: w };
       });
     });


### PR DESCRIPTION
## Summary
- prevent new constructions from crowding each other when approved
- attach offset to defence weapons
- rotate and flatten construction placements
- rotate and flatten weapon placements

## Testing
- `node -v`