### PR TITLE
Improve workforce chat

### DIFF
--- a/api/defence.js
+++ b/api/defence.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const path = require('path');
 const meshy = require('../meshy');
+const chatManager = require('../workforceChatManager');
 
 module.exports = function(store, broadcast) {
   const router = express.Router();
@@ -78,6 +79,7 @@ module.exports = function(store, broadcast) {
       }
 
       store.updateProposal(id, index, { status });
+      chatManager.resolveProposal(id, index, status);
       res.json({ status });
     } catch {
       res.status(500).json({ error: 'failed' });

--- a/api/workforce.js
+++ b/api/workforce.js
@@ -295,6 +295,18 @@ module.exports = function(institutionStore, userStore, engine, broadcast) {
     }
   });
 
+  router.post('/chat/:email/:name', (req, res) => {
+    try {
+      const { email, name } = req.params;
+      const { text } = req.body;
+      if (!text) return res.status(400).json({ error: 'text required' });
+      chatManager.addUserMessage(email, name, text);
+      res.json({ ok: true });
+    } catch {
+      res.status(500).json({ error: 'Failed to send message' });
+    }
+  });
+
   router.get('/proposals/:id', (req, res) => {
     try {
       const id = Number(req.params.id);

--- a/index.html
+++ b/index.html
@@ -53,6 +53,10 @@
     </div>
     <div id="popup-chat" class="hidden">
       <div id="chat-container"></div>
+      <div id="chat-input-row">
+        <input id="chat-input" type="text" placeholder="Type message" />
+        <button id="chat-send">Send</button>
+      </div>
     </div>
     <div id="popup-proposals" class="hidden">
       <div id="proposals-container"></div>
@@ -1364,6 +1368,9 @@ function updateStatImages() {
       proposalsDiv.style.display = 'none';
       weaponsDiv.style.display = 'none';
       if (chatInterval) clearInterval(chatInterval);
+      const input = document.getElementById('chat-input');
+      const sendBtn = document.getElementById('chat-send');
+      let lastHeight = 0;
       async function load() {
         try {
           const res = await fetch(`/api/workforce/chat/${instData.owner}/${instData.name}`);
@@ -1401,13 +1408,33 @@ function updateStatImages() {
                 }
               }
             });
-            chatContainer.scrollTop = chatContainer.scrollHeight;
+            if (chatContainer.scrollHeight !== lastHeight) {
+              chatContainer.scrollTop = chatContainer.scrollHeight;
+              lastHeight = chatContainer.scrollHeight;
+            }
           }
         } catch (err) {
         }
       }
       await load();
       chatInterval = setInterval(load, 5000);
+
+      async function send() {
+        const text = input.value.trim();
+        if (!text) return;
+        input.value = '';
+        await fetch(`/api/workforce/chat/${instData.owner}/${instData.name}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text })
+        });
+        await load();
+      }
+
+      sendBtn.onclick = send;
+      input.addEventListener('keydown', e => {
+        if (e.key === 'Enter') send();
+      });
     }
 
     async function showProposals() {

--- a/style.css
+++ b/style.css
@@ -219,12 +219,28 @@ canvas { display: block; width: 100%; height: 100%; }
   overflow-y: auto;
 }
 
+#chat-input-row {
+  display: flex;
+  gap: 4px;
+  margin-top: 6px;
+}
+#chat-input-row input {
+  flex: 1;
+  padding: 4px;
+  font-size: 14px;
+}
+#chat-input-row button {
+  padding: 4px 8px;
+  font-size: 14px;
+}
+
 .chat-msg {
   background: #333;
   color: #fff;
   padding: 4px 6px;
   border-radius: 4px;
-  font-size: 12px;
+  font-size: 14px;
+  font-family: Arial, sans-serif;
 }
 
 .chat-raw {
@@ -232,7 +248,7 @@ canvas { display: block; width: 100%; height: 100%; }
   color: #0f0;
   padding: 4px;
   border-radius: 4px;
-  font-size: 11px;
+  font-size: 12px;
   white-space: pre-wrap;
   word-break: break-all;
 }

--- a/workforceChatManager.js
+++ b/workforceChatManager.js
@@ -9,7 +9,7 @@ try {
 } catch (_) {}
 
 const CHAT_FILE = path.join(__dirname, 'chatLogs.json');
-const WORKFORCE_INTERVAL_MS = 2000; // 1 minute
+const WORKFORCE_INTERVAL_MS = 2000; // how often workers chat
 const FIRST_PROMPTS = {
   WatOx:
     'You are employee in water-oxygen extraction facility in mars. How can we increase production? Give one concise idea. the idea should be either a device, or a facility/building. specification should be clear. i dont want plan or approach. i want machines or buildings/facilities If you need more info, ask one sentence. do not output more than 2 sentences ever. help shape ideas , start from broad and help your parties to specify and make project idea tangible and concrete. based on your expertise and resume, be creative.',
@@ -34,9 +34,11 @@ class WorkforceChatManager {
   _load() {
     try {
       const data = JSON.parse(fs.readFileSync(CHAT_FILE, 'utf8'));
-      // ensure pendingProposal key for each chat
       Object.values(data).forEach(chat => {
-        if (!('pendingProposal' in chat)) chat.pendingProposal = null;
+        if (!Array.isArray(chat.messages)) chat.messages = [];
+        if (!Array.isArray(chat.workers)) chat.workers = [];
+        chat.nextIndex = chat.nextIndex || 0;
+        chat.workers.sort((a, b) => (a.director === b.director ? 0 : a.director ? 1 : -1));
       });
       return data;
     } catch {
@@ -65,8 +67,8 @@ class WorkforceChatManager {
     return this.chats[key] || {
       messages: [],
       workers: [],
-      firstPrompt: FIRST_PROMPTS[name] || 'Discuss improvements.',
-      pendingProposal: null
+      nextIndex: 0,
+      firstPrompt: FIRST_PROMPTS[name] || 'Discuss improvements.'
     };
   }
 
@@ -76,18 +78,35 @@ class WorkforceChatManager {
       this.chats[key] = {
         messages: [],
         workers: [],
-        firstPrompt: FIRST_PROMPTS[name] || 'Discuss improvements.',
-        pendingProposal: null
+        nextIndex: 0,
+        firstPrompt: FIRST_PROMPTS[name] || 'Discuss improvements.'
       };
     }
     this.chats[key].workers.push({ ...worker, initialized: false });
+    this.chats[key].workers.sort((a,b)=> (a.director===b.director?0:(a.director?1:-1)));
     this._save();
     this._start(key);
   }
 
   _start(key) {
     if (this.intervals[key]) return;
+    if (!this.chats[key].nextIndex) this.chats[key].nextIndex = 0;
     this.intervals[key] = setInterval(() => this._step(key), WORKFORCE_INTERVAL_MS);
+  }
+
+  addUserMessage(email, name, text) {
+    const key = this._key(email, name);
+    if (!this.chats[key]) {
+      this.chats[key] = {
+        messages: [],
+        workers: [],
+        nextIndex: 0,
+        firstPrompt: FIRST_PROMPTS[name] || 'Discuss improvements.'
+      };
+    }
+    this.chats[key].messages.push({ worker: 'User', text });
+    this._save();
+    this._start(key);
   }
 
   async _query(instructions, input, isDirector) {
@@ -125,10 +144,10 @@ class WorkforceChatManager {
   async _step(key) {
     const chat = this.chats[key];
     if (!chat || chat.workers.length === 0) return;
-    if (chat.pendingProposal) return;
-    for (const worker of chat.workers) {
-      const [owner, instName] = key.split('|');
-      const inst = institutionStore.findInstitution(owner, instName);
+    const worker = chat.workers[chat.nextIndex % chat.workers.length];
+    chat.nextIndex = (chat.nextIndex + 1) % chat.workers.length;
+    const [owner, instName] = key.split('|');
+    const inst = institutionStore.findInstitution(owner, instName);
       const history = chat.messages
         .slice(-10)
         .map(m => `${m.worker}: ${
@@ -158,12 +177,12 @@ class WorkforceChatManager {
         ? `Please respond in valid JSON only. ${basePrompt}`
         : basePrompt;
 
-      let result;
-      try {
-        result = await this._query(instructions, prompt, worker.director);
-      } catch {
-        continue;
-      }
+    let result;
+    try {
+      result = await this._query(instructions, prompt, worker.director);
+    } catch {
+      return;
+    }
 
       if (result.dialogue) {
         if (worker.director) {
@@ -182,17 +201,12 @@ class WorkforceChatManager {
         worker.initialized = true;
       }
 
-      if (worker.director && result.is_proposal) {
-        const [owner, instName] = key.split('|');
-        const inst = institutionStore.findInstitution(owner, instName);
-        if (inst) {
-          if (inst.name === 'Defence Base' && result.defprop) {
-            const idx = defenceStore.addProposal(inst.id, result.defprop);
-            chat.pendingProposal = { instId: inst.id, index: idx };
-          } else if (result.proposal) {
-            const { index } = institutionStore.addProposal(inst.id, result.proposal);
-            chat.pendingProposal = { instId: inst.id, index };
-          }
+    if (worker.director && result.is_proposal) {
+      if (inst) {
+        if (inst.name === 'Defence Base' && result.defprop) {
+          defenceStore.addProposal(inst.id, result.defprop);
+        } else if (result.proposal) {
+          institutionStore.addProposal(inst.id, result.proposal);
         }
       }
     }
@@ -205,13 +219,10 @@ class WorkforceChatManager {
     const key = this._key(inst.owner, inst.name);
     const chat = this.chats[key];
     if (!chat) return;
-    if (chat.pendingProposal && chat.pendingProposal.instId === instId && chat.pendingProposal.index === index) {
-      chat.pendingProposal = null;
-      let msg = `Proposal ${status}`;
-      if (note) msg += `: ${note}`;
-      chat.messages.push({ worker: 'System', text: msg });
-      this._save();
-    }
+    let msg = `Proposal ${status}`;
+    if (note) msg += `: ${note}`;
+    chat.messages.push({ worker: 'System', text: msg });
+    this._save();
   }
 }
 


### PR DESCRIPTION
## Summary
- maintain order of worker chat so directors speak last
- allow user messages via new API endpoint
- send proposal results to chat for defence and normal cases
- clean up chat UI and style
- prevent chat scroll jitter

## Testing
- `npm test` *(fails: Missing script)*