### PR TITLE
Improve proposal approval feedback and cost deduction

### DIFF
--- a/proposals.js
+++ b/proposals.js
@@ -79,6 +79,9 @@ export function renderProposals(container, proposals, instId, institutionDataMap
     approve.disabled = true;
     const deny = document.createElement('button');
     deny.textContent = 'Deny';
+    const statusDiv = document.createElement('div');
+    statusDiv.style.marginTop = '4px';
+    statusDiv.style.fontSize = '12px';
 
     function checkReady() {
       const all = [...table.querySelectorAll('button')].every(b => b.disabled);
@@ -86,6 +89,9 @@ export function renderProposals(container, proposals, instId, institutionDataMap
     }
 
     approve.onclick = async () => {
+      approve.disabled = true;
+      deny.disabled = true;
+      approve.textContent = 'Loading...';
       const res = await fetch(`/api/workforce/proposals/${instId}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -103,8 +109,19 @@ export function renderProposals(container, proposals, instId, institutionDataMap
             }
           }
         }
+        if (data.result && data.result.feasible) {
+          approve.textContent = 'Started';
+          approve.style.backgroundColor = '#0a0';
+          statusDiv.textContent = 'Status: approved';
+        } else {
+          approve.textContent = 'Project failed';
+          approve.style.backgroundColor = '#a00';
+          statusDiv.textContent = 'Status: rejected';
+        }
+      } else {
+        approve.textContent = 'Error';
+        approve.style.backgroundColor = '#a00';
       }
-      card.remove();
     };
 
     deny.onclick = async () => {
@@ -118,6 +135,7 @@ export function renderProposals(container, proposals, instId, institutionDataMap
 
     card.appendChild(approve);
     card.appendChild(deny);
+    card.appendChild(statusDiv);
     container.appendChild(card);
   });
   }

--- a/server.js
+++ b/server.js
@@ -35,7 +35,16 @@ const INSTITUTION_PRICES = {
 const loginRoute = require('./api/login')(client, verifySid);
 const verifyRoute = require('./api/verify')(client, verifySid, userStore);
 const stateRoute = require('./api/state')(userStore);
-const workforceRoute = require('./api/workforce')(institutionStore, userStore, engine, broadcast);
+function sendToEmail(email, data) {
+  const msg = JSON.stringify(data);
+  for (const [id, ws] of clients.entries()) {
+    if (emails.get(id) === email && ws.readyState === WebSocket.OPEN) {
+      ws.send(msg);
+    }
+  }
+}
+
+const workforceRoute = require('./api/workforce')(institutionStore, userStore, engine, broadcast, sendToEmail);
 const defenceRoute = require('./api/defence')(defenceStore, broadcast);
 chatManager.initFromInstitutions(institutionStore.getInstitutions());
 


### PR DESCRIPTION
## Summary
- send targeted money updates to players via `sendToEmail`
- deduct proposal cost when approving and return updated money
- show loading state and result on proposal approval

## Testing
- `node --check server.js`
- `node --check api/workforce.js`
- `node --check proposals.js`
- `npm test` *(fails: Missing script)*