### PR TITLE
Add defence proposal debug logs

### DIFF
--- a/api/defence.js
+++ b/api/defence.js
@@ -12,6 +12,7 @@ module.exports = function(store, broadcast) {
   router.get('/proposals/:id', (req, res) => {
     try {
       const id = Number(req.params.id);
+      console.log('[DEFENCE API] GET proposals', { id });
       const proposals = store.getProposals(id);
       res.json({ proposals });
     } catch {
@@ -23,6 +24,7 @@ module.exports = function(store, broadcast) {
     try {
       const id = Number(req.params.id);
       const { index, approve } = req.body;
+      console.log('[DEFENCE API] POST proposals', { id, index, approve });
       const props = store.getProposals(id);
       const prop = props[index];
       if (!prop) return res.status(404).json({ error: 'not found' });
@@ -91,6 +93,7 @@ module.exports = function(store, broadcast) {
       const id = Number(req.params.id);
       const proposal = req.body.proposal;
       if (!proposal) return res.status(400).json({ error: 'proposal required' });
+      console.log('[DEFENCE API] ADD proposal', { id, proposal });
       const idx = store.addProposal(id, proposal);
       res.json({ index: idx });
     } catch {
@@ -101,6 +104,7 @@ module.exports = function(store, broadcast) {
   router.get('/weapons/:id', (req, res) => {
     try {
       const id = Number(req.params.id);
+      console.log('[DEFENCE API] GET weapons', { id });
       const weapons = store.getWeapons(id);
       res.json({ weapons });
     } catch {

--- a/defProposals.js
+++ b/defProposals.js
@@ -1,5 +1,6 @@
 export function renderDefProposals(container, proposals, instId) {
   container.innerHTML = '';
+  console.log('[DEFENCE UI] renderDefProposals', { instId, count: proposals ? proposals.length : 0 });
   if (!Array.isArray(proposals) || proposals.length === 0) {
     container.innerHTML = '<div style="color:#fff">No proposals</div>';
     return;

--- a/defenceBaseStore.js
+++ b/defenceBaseStore.js
@@ -5,7 +5,8 @@ const FILE = path.join(__dirname, 'defence_base.json');
 
 function load() {
   try {
-    return JSON.parse(fs.readFileSync(FILE, 'utf8'));
+    const data = JSON.parse(fs.readFileSync(FILE, 'utf8'));
+    return data;
   } catch {
     return {};
   }
@@ -22,7 +23,9 @@ function ensure(data, id) {
 
 function getProposals(id) {
   const data = load();
-  return (data[id] && data[id].proposals) || [];
+  const list = (data[id] && data[id].proposals) || [];
+  console.log('[DEFENCE STORE] getProposals', { id, count: list.length });
+  return list;
 }
 
 function addProposal(id, proposal) {
@@ -30,6 +33,7 @@ function addProposal(id, proposal) {
   const entry = ensure(data, id);
   const full = Object.assign({ status: 'pending' }, proposal);
   entry.proposals.push(full);
+  console.log('[DEFENCE STORE] addProposal', { id, proposal: full });
   save(data);
   return entry.proposals.length - 1;
 }
@@ -44,18 +48,22 @@ function updateProposal(id, index, updates) {
     entry.proposals.splice(index, 1);
   }
   save(data);
+  console.log('[DEFENCE STORE] updateProposal', { id, index, updates });
   return p;
 }
 
 function getWeapons(id) {
   const data = load();
-  return (data[id] && data[id].weapons) || [];
+  const list = (data[id] && data[id].weapons) || [];
+  console.log('[DEFENCE STORE] getWeapons', { id, count: list.length });
+  return list;
 }
 
 function addWeapon(id, weapon) {
   const data = load();
   const entry = ensure(data, id);
   entry.weapons.push(weapon);
+  console.log('[DEFENCE STORE] addWeapon', { id, weapon });
   save(data);
   return entry.weapons.length - 1;
 }
@@ -67,6 +75,7 @@ function updateWeapon(id, index, updates) {
   if (!w) return null;
   Object.assign(w, updates);
   save(data);
+  console.log('[DEFENCE STORE] updateWeapon', { id, index, updates });
   return w;
 }
 

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
     </div>
   </div>
   <script type="module">
+  const DEBUG_LOG = false;
   import * as THREE from 'three';
   import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
   import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
@@ -928,15 +929,17 @@ function updateStatImages() {
         weaponMap[inst.id][idx] = { obj, data: w };
 
         // Debug: log weapon placement when the generated model is loaded
-        console.log('[DEBUG] Weapon model loaded', {
-          institution: inst.id,
-          index: idx,
-          position: {
-            x: obj.position.x,
-            y: obj.position.y,
-            z: obj.position.z
-          }
-        });
+        if (DEBUG_LOG) {
+          console.log('[DEBUG] Weapon model loaded', {
+            institution: inst.id,
+            index: idx,
+            position: {
+              x: obj.position.x,
+              y: obj.position.y,
+              z: obj.position.z
+            }
+          });
+        }
       }, undefined, () => {
         if (inst.weapons[idx] !== w) return;
         const obj = createPlaceholder(w.scale || 1, 0xff0000);
@@ -966,22 +969,24 @@ function updateStatImages() {
     projectiles.push({ obj: clone, tech, cat, params, start, target, stage: 0, speed: 0 });
 
     // Debug: log weapon firing start information
-    console.log('[DEBUG] Fire weapon', {
-      weaponTech: tech,
-      weaponCategory: cat,
-      params,
-      characterPosition: {
-        x: target.x,
-        y: target.y,
-        z: target.z
-      },
-      startPosition: {
-        x: start.x,
-        y: start.y,
-        z: start.z
-      },
-      animation: activeAction && activeAction._clip ? activeAction._clip.name : 'none'
-    });
+    if (DEBUG_LOG) {
+      console.log('[DEBUG] Fire weapon', {
+        weaponTech: tech,
+        weaponCategory: cat,
+        params,
+        characterPosition: {
+          x: target.x,
+          y: target.y,
+          z: target.z
+        },
+        startPosition: {
+          x: start.x,
+          y: start.y,
+          z: start.z
+        },
+        animation: activeAction && activeAction._clip ? activeAction._clip.name : 'none'
+      });
+    }
   }
 
   function fireAllWeapons() {
@@ -1459,6 +1464,7 @@ function updateStatImages() {
       if (chatInterval) { clearInterval(chatInterval); chatInterval = null; }
       const container = document.getElementById('proposals-container');
       container.innerHTML = '<div class="spinner" style="height:100px;color:#fff">Loading...</div>';
+      if (DEBUG_LOG) console.log('[DEFENCE UI] showProposals', { instId: id });
       try {
         if (instData.name === 'Defence Base') {
           const res = await fetch(`/api/defence/proposals/${id}`);
@@ -2193,13 +2199,15 @@ function updateStatImages() {
       model.add(footstepSound);
 
       // Debug: log when player model is loaded and its starting position
-      console.log('[DEBUG] Player model loaded', {
-        position: {
-          x: startPosition[0],
-          y: startPosition[1],
-          z: startPosition[2]
-        }
-      });
+      if (DEBUG_LOG) {
+        console.log('[DEBUG] Player model loaded', {
+          position: {
+            x: startPosition[0],
+            y: startPosition[1],
+            z: startPosition[2]
+          }
+        });
+      }
 
       // Position the model based on saved state
       model.position.set(startPosition[0], startPosition[1], startPosition[2]);
@@ -2307,7 +2315,7 @@ function updateStatImages() {
     const key = e.code.toLowerCase().replace('key', '').replace('arrow','');
     if (keys.hasOwnProperty(key)) keys[key] = true;
     if (e.code === 'KeyK') {
-      console.log('[DEBUG] Key K pressed');
+      if (DEBUG_LOG) console.log('[DEBUG] Key K pressed');
       fireAllWeapons();
     }
   });

--- a/workforceChatManager.js
+++ b/workforceChatManager.js
@@ -238,6 +238,10 @@ class WorkforceChatManager {
 
         if (result.is_proposal && propData && inst) {
           if (inst.name === 'Defence Base') {
+            console.log('[WORKFORCE] adding defence proposal', {
+              institution: inst.id,
+              proposal: propData
+            });
             defenceStore.addProposal(inst.id, propData);
           } else {
             institutionStore.addProposal(inst.id, propData);


### PR DESCRIPTION
## Summary
- add DEBUG_LOG toggle and wrap debug messages in index.html
- log defence-related UI actions
- log defence proposal actions on the server and store
- log when workforce adds a defence proposal

## Testing
- `node -c defenceBaseStore.js`
- `node -c api/defence.js`
- `node -c workforceChatManager.js`
- `node -c defProposals.js`
