### PR TITLE
Fix die animation loop

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,6 +496,8 @@ function updateStatImages() {
 
     if (oxygen <= 0 || hydration <= 0) {
       dead = true;
+      isMovingForward = false;
+      isRunning = false;
       deathOverlay.style.display = 'flex';
       if (dieAction) switchAnimation(dieAction);
     }
@@ -761,7 +763,11 @@ function updateStatImages() {
       if (idleClip) idle = m.clipAction(idleClip);
       if (walkClip) walk = m.clipAction(walkClip);
       if (runClip) run = m.clipAction(runClip);
-      if (dieClip) die = m.clipAction(dieClip);
+      if (dieClip) {
+        die = m.clipAction(dieClip);
+        die.setLoop(THREE.LoopOnce, 1);
+        die.clampWhenFinished = true;
+      }
     }
     if (idle) idle.play();
     remotePlayers[id] = { model: remote, mixer: m, idle, walk, run, die, active: idle };
@@ -1651,8 +1657,8 @@ function updateStatImages() {
       type: 'state',
       position: [model.position.x, model.position.y, model.position.z],
       rotation: model.rotation.y,
-      moving: isMovingForward,
-      running: isRunning,
+      moving: dead ? false : isMovingForward,
+      running: dead ? false : isRunning,
       health,
       hydration,
       oxygen,
@@ -2249,6 +2255,10 @@ function updateStatImages() {
       walkAction = mixer.clipAction(animations.find(a => a.name.toLowerCase() === 'walk'));
       runAction = mixer.clipAction(animations.find(a => a.name.toLowerCase() === 'run'));
       dieAction = mixer.clipAction(animations.find(a => a.name.toLowerCase() === 'die'));
+      if (dieAction) {
+        dieAction.setLoop(THREE.LoopOnce, 1);
+        dieAction.clampWhenFinished = true;
+      }
       playerAnimations = animations;
 
 
@@ -2496,6 +2506,7 @@ function updateStatImages() {
     if (ghostMixer) ghostMixer.update(dt);
 
     if (model && terrainMeshes.length > 0) {
+    if (!dead) {
         // PHYSICS - Apply gravity if not on ground
         if (!onGround) {
             velocity.y -= gravity * dt;
@@ -2605,6 +2616,7 @@ function updateStatImages() {
                 footstepSound.setVolume(vol);
             }
         }
+    }
 
         if (model.position.y < -100) {
           model.position.y = 60;


### PR DESCRIPTION
## Summary
- ensure die animation only plays once for the player and remote players
- stop movement and animations after death so other animations cannot play

## Testing
- `npm test` *(fails: Missing script)*