### PR TITLE
Disable 3D controls when institution popup open

### DIFF
--- a/index.html
+++ b/index.html
@@ -1648,10 +1648,10 @@ function updateStatImages() {
       weaponsTabBtn.style.display = 'none';
     }
 
-    function closePopup() {
-      popup.style.display = 'none';
-      institutionPopupOpen = false;
-      document.removeEventListener('keydown', escHandler);
+   function closePopup() {
+     popup.style.display = 'none';
+     institutionPopupOpen = false;
+     document.removeEventListener('keydown', escHandler);
       if (chatInterval) {
         clearInterval(chatInterval);
         chatInterval = null;
@@ -2447,6 +2447,7 @@ function updateStatImages() {
   // Input state
   const keys = { w: false, a: false, s: false, d: false, arrowup: false, arrowleft: false, arrowright: false, arrowdown: false, space: false, shift: false };
   window.addEventListener('keydown', e => {
+    if (institutionPopupOpen) return;
     const key = e.code.toLowerCase().replace('key', '').replace('arrow','');
     if (keys.hasOwnProperty(key)) keys[key] = true;
     if (e.code === 'ShiftLeft' || e.code === 'ShiftRight') keys.shift = true;
@@ -2459,6 +2460,7 @@ function updateStatImages() {
     }
   });
   window.addEventListener('keyup', e => {
+    if (institutionPopupOpen) return;
     const key = e.code.toLowerCase().replace('key', '').replace('arrow','');
     if (keys.hasOwnProperty(key)) keys[key] = false;
     if (e.code === 'ShiftLeft' || e.code === 'ShiftRight') keys.shift = false;


### PR DESCRIPTION
## Summary
- revert popup focus changes
- skip movement key handlers while institution popup is open

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(fails: username is required)*