### PR TITLE
Improve GLB light loading with hierarchy logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,9 +116,18 @@ const icons = {
     return mesh;
   }
 
+  function printGLTFHierarchy(obj, prefix = '') {
+    if (!obj || typeof obj.traverse !== 'function') return;
+    console.log(prefix + (obj.name || obj.type));
+    obj.children?.forEach(child => printGLTFHierarchy(child, prefix + '  '));
+  }
+
   function addPointLightsFromGLTF(gltf) {
-    if (!gltf || !gltf.scene) return;
-    gltf.scene.traverse(node => {
+    if (!gltf) return;
+    const root = gltf.scene || (gltf.scenes && gltf.scenes[0]);
+    if (!root || typeof root.traverse !== 'function') return;
+    if (DEBUG_LOG) printGLTFHierarchy(root);
+    root.traverse(node => {
       if (node.isPointLight) {
         scene.add(node);
       }
@@ -393,7 +402,9 @@ function updateStatImages() {
     }
     const loader = new GLTFLoader();
     loader.load(inst.url, gltf => {
-      ghostInstitution = gltf.scene;
+      const root = gltf.scene || (gltf.scenes && gltf.scenes[0]);
+      if (!root) return;
+      ghostInstitution = root;
       addPointLightsFromGLTF(gltf);
       ghostInstitution.scale.setScalar(inst.scale || 1);
       const box = new THREE.Box3().setFromObject(ghostInstitution);
@@ -1007,7 +1018,8 @@ function handleClick(event) {
       const loader = new GLTFLoader();
       loader.load(c.url, gltf => {
         if (inst.constructions[idx] !== c) return; // ignore outdated load
-        const obj = gltf.scene;
+        const obj = gltf.scene || (gltf.scenes && gltf.scenes[0]);
+        if (!obj) return;
         addPointLightsFromGLTF(gltf);
         const offset = Array.isArray(c.offset)
           ? new THREE.Vector3().fromArray(c.offset)
@@ -1090,7 +1102,8 @@ function handleClick(event) {
     if (existing) scene.remove(existing);
     const loader = new GLTFLoader();
     loader.load('flag.glb', gltf => {
-      const obj = gltf.scene;
+      const obj = gltf.scene || (gltf.scenes && gltf.scenes[0]);
+      if (!obj) return;
       obj.position.copy(pos);
       scene.add(obj);
       flagObjects[id] = obj;
@@ -1166,7 +1179,8 @@ function handleClick(event) {
       const loader = new GLTFLoader();
       loader.load(w.model, gltf => {
         if (inst.weapons[idx] !== w) return; // ignore outdated load
-        const obj = gltf.scene;
+        const obj = gltf.scene || (gltf.scenes && gltf.scenes[0]);
+        if (!obj) return;
         addPointLightsFromGLTF(gltf);
       obj.scale.setScalar(w.scale || 1);
       obj.rotation.y = inst.rotation || 0;
@@ -1435,7 +1449,8 @@ function handleClick(event) {
     if (!def) return;
     const loader = new GLTFLoader();
     loader.load(def.url, gltf => {
-      const obj = gltf.scene;
+      const obj = gltf.scene || (gltf.scenes && gltf.scenes[0]);
+      if (!obj) return;
       obj.userData.animations = gltf.animations || [];
       addPointLightsFromGLTF(gltf);
       obj.scale.setScalar(inst.scale || def.scale || 1);
@@ -2449,7 +2464,8 @@ function showInstitutionPopup(id) {
   groundLoader.load(
     'terrain_s.gltf', // Replace this with the path to your ground GLTF file
     (gltf) => {
-      gltfTerrain = gltf.scene;
+      gltfTerrain = gltf.scene || (gltf.scenes && gltf.scenes[0]);
+      if (!gltfTerrain) return;
       addPointLightsFromGLTF(gltf);
 
       gltfTerrain.scale.set(terrainScaleFactor, terrainScaleFactor, terrainScaleFactor);
@@ -2566,7 +2582,8 @@ function showInstitutionPopup(id) {
   new GLTFLoader().load(
     'character.glb',
     gltf => {
-      model = gltf.scene;
+      model = gltf.scene || (gltf.scenes && gltf.scenes[0]);
+      if (!model) return;
       addPointLightsFromGLTF(gltf);
       model.scale.set(modelScale, modelScale, modelScale);
       model.rotation.y =0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
-  "name": "houses_of_mars",
+  "name": "houses-of-mars",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "houses-of-mars",
+      "version": "1.0.0",
+      "license": "ISC",
       "dependencies": {
         "dotenv": "^16.5.0",
         "express": "^4.18.2",

--- a/test_Char.html
+++ b/test_Char.html
@@ -231,18 +231,29 @@
       document.addEventListener('keydown', onKeyDown);
     }
 
+    function printGLTFHierarchy(obj, prefix = '') {
+      if (!obj || typeof obj.traverse !== 'function') return;
+      console.log(prefix + (obj.name || obj.type));
+      obj.children?.forEach(child => printGLTFHierarchy(child, prefix + '  '));
+    }
+
     function loadGLBModel() {
       const loader = new THREE.GLTFLoader();
 
       loader.load(
         GLB_URL,
         function(gltf) {
-          model = gltf.scene;
-          gltf.scene.traverse(node => {
-            if (node.isPointLight) {
-              scene.add(node);
-            }
-          });
+          model = gltf.scene || (gltf.scenes && gltf.scenes[0]);
+          if (!model) return;
+          const root = gltf.scene || (gltf.scenes && gltf.scenes[0]);
+          if (root && typeof root.traverse === 'function') {
+            printGLTFHierarchy(root);
+            root.traverse(node => {
+              if (node.isPointLight) {
+                scene.add(node);
+              }
+            });
+          }
           model.traverse(child => {
             if (child.isMesh) {
               child.castShadow = true;


### PR DESCRIPTION
## Summary
- add `printGLTFHierarchy` helper
- use traversal checks in `addPointLightsFromGLTF`
- show GLB hierarchy when loading models in the character test page

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Error: username is required)*

------
https://chatgpt.com/codex/tasks/task_e_6839fbfaba74832992f0d37e886d36fe