### PR TITLE
Add progress text to asset preloader

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,12 @@
       <div id="login-error"></div>
     </div>
   </div>
+  <div id="loading-container" class="loading-container hidden">
+    <div class="loading-box">
+      <div id="loading-bar" class="loading-bar"></div>
+    </div>
+    <div id="loading-text" class="loading-text"></div>
+  </div>
   <div id="money-display">Money: 0</div>
   <div id="status-panel">
     <div class="stat"><img id="health-img" /></div>
@@ -91,6 +97,7 @@
   import { renderProposals } from './proposals.js';
   import { renderDefProposals } from './defProposals.js';
 
+  import { preloadAssets } from "./preloadAssets.js";
 
   let playerEmail = null;
   let playerMoney = 0;
@@ -253,6 +260,20 @@ function updateStatImages() {
       updateStatImages();
       playerEmail = email;
       document.getElementById('login-container').style.display = 'none';
+      const loaderEl = document.getElementById('loading-container');
+      loaderEl.classList.remove('hidden');
+      document.getElementById('loading-bar').style.width = '0%';
+      document.getElementById('loading-text').textContent = 'Fetching files list...';
+      await preloadAssets(
+        PRELOAD_ASSETS,
+        p => {
+          document.getElementById('loading-bar').style.width = `${Math.floor(p * 100)}%`;
+        },
+        msg => {
+          document.getElementById('loading-text').textContent = msg;
+        }
+      );
+      loaderEl.classList.add('hidden');
       initNetwork();
       updateMoneyDisplay();
       return true;
@@ -312,14 +333,19 @@ function updateStatImages() {
     'Depot': 'depot.mp3',
     'Defence Base': 'defence_base.mp3'
   };
-
   const weaponAudioFiles = {
-    laser: 'laser.mp3',
-    bullet: 'bullet.mp3',
-    missile: 'missile.mp3',
-    drone: 'drone.mp3',
-    kamikaze: 'kamikaze.mp3'
+    laser: "laser.mp3",
+    bullet: "bullet.mp3",
+    missile: "missile.mp3",
+    drone: "drone.mp3",
+    kamikaze: "kamikaze.mp3"
   };
+
+  const PRELOAD_ASSETS = [
+    "watox.glb","agriFood.glb","base.glb","defbase.glb","character.glb","flag.glb",
+    "watox.mp3","agrifood.mp3","depot.mp3","defence_base.mp3",
+    "laser.mp3","bullet.mp3","missile.mp3","drone.mp3","kamikaze.mp3","walking.mp3"
+  ];
 
   const panel = document.getElementById('institution-panel');
   const panelTab = panel.querySelector('.panel-tab');
@@ -764,7 +790,21 @@ function handleClick(event) {
     updateStatImages();
     playerEmail = email;
     localStorage.setItem('playerEmail', email);
+    const loaderEl = document.getElementById('loading-container');
+    loaderEl.classList.remove('hidden');
+    document.getElementById('loading-bar').style.width = '0%';
+    document.getElementById('loading-text').textContent = 'Fetching files list...';
     document.getElementById('login-container').style.display = 'none';
+    await preloadAssets(
+      PRELOAD_ASSETS,
+      p => {
+        document.getElementById('loading-bar').style.width = `${Math.floor(p * 100)}%`;
+      },
+      msg => {
+        document.getElementById('loading-text').textContent = msg;
+      }
+    );
+    loaderEl.classList.add('hidden');
     initNetwork();
     updateMoneyDisplay();
   }

--- a/preloadAssets.js
+++ b/preloadAssets.js
@@ -1,0 +1,69 @@
+export async function preloadAssets(urls, onProgress = () => {}, onStatus = () => {}) {
+  const cache = await caches.open('asset-cache');
+  let total = 0;
+  const sizes = {};
+
+  onStatus('Fetching files list...');
+
+  // Attempt to obtain file sizes using HEAD requests
+  for (const url of urls) {
+    try {
+      const res = await fetch(url, { method: 'HEAD' });
+      const len = parseInt(res.headers.get('Content-Length'));
+      if (!isNaN(len)) {
+        sizes[url] = len;
+        total += len;
+      }
+    } catch (e) {
+      sizes[url] = 0;
+    }
+  }
+
+  // If we couldn't determine any sizes, fall back to counting files
+  if (!total) {
+    total = urls.length;
+    for (const url of urls) sizes[url] = 1;
+  }
+
+  let loaded = 0;
+  for (const url of urls) {
+    const display = url.split('/').pop();
+    onStatus(`Downloading ${display}...`);
+
+    const match = await cache.match(url);
+    if (match) {
+      loaded += sizes[url] || 1;
+      onProgress(Math.min(loaded / total, 1));
+      continue;
+    }
+
+    const response = await fetch(url);
+
+    if (sizes[url]) {
+      const reader = response.body.getReader();
+      const chunks = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        loaded += value.length;
+        onProgress(Math.min(loaded / total, 1));
+        chunks.push(value);
+      }
+
+      const blob = new Blob(chunks);
+      const resp = new Response(blob, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+      await cache.put(url, resp);
+    } else {
+      const blob = await response.blob();
+      await cache.put(url, new Response(blob));
+      loaded += 1; // approximate
+      onProgress(Math.min(loaded / total, 1));
+    }
+  }
+
+  onStatus('Loading complete');
+}

--- a/style.css
+++ b/style.css
@@ -256,3 +256,37 @@ canvas { display: block; width: 100%; height: 100%; }
 .hidden { display: none; }
 .popup-actions { margin-top: 8px; display: flex; gap: 4px; }
 
+
+.loading-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: #000c;
+  z-index: 9;
+}
+.loading-box {
+  width: 50%;
+  height: 20px;
+  background: #333;
+  border-radius: 4px;
+  overflow: hidden;
+}
+.loading-bar {
+  height: 100%;
+  width: 0%;
+  background: #0a0;
+  transition: width 0.2s;
+}
+.loading-text {
+  margin-top: 8px;
+  color: #fff;
+  font-size: 14px;
+  text-align: center;
+}
+


### PR DESCRIPTION
## Summary
- show progress text while loading assets and animate progress bar
- update auto-login and verify flow to reset and display progress overlay
- refine `preloadAssets` helper to report status messages

## Testing
- `node -e "require('./preloadAssets.js'); console.log('ok')"`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683c48ae44c08329b510beb99a1ca684