### PR TITLE
Ensure respawn button stays on top

### DIFF
--- a/style.css
+++ b/style.css
@@ -128,10 +128,15 @@ canvas { display: block; width: 100%; height: 100%; }
   color: #fff;
   font-family: sans-serif;
   display: none;
-  z-index: 10;
+  z-index: 10000;
   align-items: center;
   justify-content: center;
   flex-direction: column;
+}
+
+#respawn-btn {
+  position: relative;
+  z-index: 10001;
 }
 
 /* Login */


### PR DESCRIPTION
## Summary
- make the death overlay z-index extremely high
- add z-index to respawn button so it is always clickable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683ca1cbe2f08329927ec962a00aca5c