### PR TITLE
Fix video autoplay and fullscreen loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     </div>
     <div id="loading-text" class="loading-text"></div>
     <img id="loading-image" class="loading-image hidden" />
-    <video id="intro-video" class="intro-video hidden" src="intro.mp4" preload="auto"></video>
+    <video id="intro-video" class="intro-video hidden" src="intro.mp4" preload="auto" autoplay muted playsinline></video>
   </div>
   <div id="money-display">Money: 0</div>
   <div id="status-panel">

--- a/style.css
+++ b/style.css
@@ -270,8 +270,9 @@ canvas { display: block; width: 100%; height: 100%; }
   height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
+  padding-top: 20px;
   background: #000c;
   z-index: 9;
 }
@@ -297,12 +298,17 @@ canvas { display: block; width: 100%; height: 100%; }
 
 .loading-image,
 .intro-video {
-  max-width: 80%;
-  max-height: 60%;
-  margin-top: 20px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  margin: 0;
 }
 
 .intro-video {
   background: #000;
+  z-index: 10;
 }
 


### PR DESCRIPTION
## Summary
- make intro video autoplay and work without user gesture
- show loader on top of fullscreen slideshow image
- make intro video cover screen just like the images

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683caed00f188329b580548a15171662