### PR TITLE
Enhance loading overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     </div>
   </div>
   <div id="loading-container" class="loading-container hidden">
+    <div id="loading-tip" class="loading-tip"></div>
     <div class="loading-box">
       <div id="loading-bar" class="loading-bar"></div>
     </div>
@@ -107,25 +108,41 @@
   let startPosition = [70, 100, -50];
 
   const SLIDES = ['healthfull.png', 'transport.png', 'dangerousChemicals.png'];
+  const SLIDE_TIPS = [
+    'Stay healthy to survive the harsh environment.',
+    'Efficient transport keeps the colony running.',
+    'Handle chemicals with extreme caution.'
+  ];
   const SLIDE_DURATION = 3000; // ms
   let slideIndex = 0;
   let slideTimer = null;
+  let slideshowAudio = null;
 
   function startSlideshow() {
     const img = document.getElementById('loading-image');
+    const tipEl = document.getElementById('loading-tip');
     if (!img) return;
     img.classList.remove('hidden');
     img.src = SLIDES[0];
+    if (tipEl) tipEl.textContent = SLIDE_TIPS[0] || '';
     slideIndex = 0;
+    if (!slideshowAudio) {
+      slideshowAudio = new Audio('intro_music.mp3');
+      slideshowAudio.loop = true;
+    }
+    try { slideshowAudio.play(); } catch (e) { console.error('Audio play failed', e); }
     slideTimer = setInterval(() => {
       slideIndex = (slideIndex + 1) % SLIDES.length;
       img.src = SLIDES[slideIndex];
+      if (tipEl) tipEl.textContent = SLIDE_TIPS[slideIndex] || '';
     }, SLIDE_DURATION);
   }
 
   function stopSlideshow() {
     if (slideTimer) clearInterval(slideTimer);
     slideTimer = null;
+    const tipEl = document.getElementById('loading-tip');
+    if (tipEl) tipEl.textContent = '';
   }
 
   async function playIntroSequence() {
@@ -141,6 +158,10 @@
       try { await video.play(); } catch (e) { console.error('Video play failed', e); }
       await new Promise(res => video.onended = res);
       video.classList.add('hidden');
+    }
+    if (slideshowAudio) {
+      slideshowAudio.pause();
+      slideshowAudio.currentTime = 0;
     }
     const loaderEl = document.getElementById('loading-container');
     loaderEl.classList.add('hidden');

--- a/style.css
+++ b/style.css
@@ -270,11 +270,11 @@ canvas { display: block; width: 100%; height: 100%; }
   height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: center;
-  padding-top: 20px;
+  padding: 20px 0;
   background: #000c;
-  z-index: 9;
+  z-index: 11;
 }
 .loading-box {
   width: 50%;
@@ -282,18 +282,32 @@ canvas { display: block; width: 100%; height: 100%; }
   background: #333;
   border-radius: 4px;
   overflow: hidden;
+  position: relative;
+  z-index: 20;
 }
 .loading-bar {
   height: 100%;
   width: 0%;
   background: #0a0;
   transition: width 0.2s;
+  position: relative;
+  z-index: 20;
 }
 .loading-text {
-  margin-top: 8px;
+  margin-top: 4px;
   color: #fff;
   font-size: 14px;
   text-align: center;
+  position: relative;
+  z-index: 20;
+}
+
+.loading-tip {
+  color: #fff;
+  font-size: 16px;
+  text-align: center;
+  position: relative;
+  z-index: 20;
 }
 
 .loading-image,
@@ -305,10 +319,10 @@ canvas { display: block; width: 100%; height: 100%; }
   height: 100%;
   object-fit: cover;
   margin: 0;
+  z-index: 10;
 }
 
 .intro-video {
   background: #000;
-  z-index: 10;
 }
 


### PR DESCRIPTION
## Summary
- display loading tips above the slideshow/video
- keep the loading bar at the bottom of the loading screen
- play a background mp3 from the start of the slideshow until the intro video finishes
- ensure loading overlay appears on top of the video

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_683cb12c41c883299685b1515d28acc0