### PR TITLE
Fix handleClick null reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,6 +608,7 @@ if (window.location.protocol === 'https:') {
       alert('Not enough money');
       return;
     }
+    if (placingInstitution && ghostInstitution && currentInstitution) {
       const box = new THREE.Box3().setFromObject(ghostInstitution);
       const radius = Math.max(box.max.x - box.min.x, box.max.z - box.min.z) * 0.6;
       const lowestGround = findLowestPointInArea(
@@ -665,6 +666,7 @@ if (window.location.protocol === 'https:') {
       placingApplication = false;
       applicationInfo = null;
       return;
+    }
 
 
     // Raycast to detect institution click


### PR DESCRIPTION
## Summary
- guard institution placement logic with a condition so Box3 isn't called on null

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Twilio credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_683e95c8d5b08329a4b19ae474af4678