### PR TITLE
Fix loading screen visibility on first load

### DIFF
--- a/style.css
+++ b/style.css
@@ -258,7 +258,9 @@ canvas { display: block; width: 100%; height: 100%; }
   word-break: break-all;
 }
 
-.hidden { display: none; }
+.hidden {
+  display: none !important;
+}
 .popup-actions { margin-top: 8px; display: flex; gap: 4px; }
 
 


### PR DESCRIPTION
## Summary
- ensure `.hidden` overrides display rules
- prevents the loading screen from covering the login form on first visit

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683ece52d5c483299b41e95b1a06fad7