### PR TITLE
Add logs for workforce debugging

### DIFF
--- a/api/workforce.js
+++ b/api/workforce.js
@@ -197,6 +197,7 @@ module.exports = function(institutionStore, userStore, engine, broadcast, sendTo
   router.post('/generate/:id', async (req, res) => {
     try {
       const institutionId = Number(req.params.id);
+      console.log('Generating applicants for institution', institutionId);
       const institution = institutionStore.getInstitution(institutionId);
 
       const institutionName = institution ? institution.name : 'Mars Colony';
@@ -205,7 +206,8 @@ module.exports = function(institutionStore, userStore, engine, broadcast, sendTo
       const workers = await generateWorkers(num, institutionName);
 
       res.json({ workers });
-    } catch {
+    } catch (err) {
+      console.error('Error generating workers:', err);
       res.status(500).json({ error: 'Failed to generate workers' });
     }
   });

--- a/index.html
+++ b/index.html
@@ -1902,7 +1902,9 @@ function showInstitutionPopup(id) {
     container.innerHTML = '<div class="spinner" style="display: flex; justify-content: center; align-items: center; height: 200px; color: #fff;">Loading applicants...</div>';
 
     try {
+      console.log('Requesting applicants from', `/api/workforce/generate/${id}`);
       const res = await fetch(`/api/workforce/generate/${id}`, { method: 'POST' });
+      console.log('Generate response status', res.status);
       if (!res.ok) {
         throw new Error(`HTTP error! status: ${res.status}`);
       }
@@ -2000,6 +2002,7 @@ function showInstitutionPopup(id) {
         container.appendChild(card);
       });
     } catch (err) {
+      console.error('Failed to load applicants', err);
       container.innerHTML = '<div style="color: #ff6666; text-align: center;">Failed to load applicants. Please try again.</div>';
     }
   }

--- a/server.js
+++ b/server.js
@@ -19,6 +19,9 @@ const accountSid = process.env.TWILIO_ACCOUNT_SID;
 const authToken = process.env.TWILIO_AUTH_TOKEN;
 const verifySid = process.env.TWILIO_VERIFY_SERVICE_SID;
 const client = twilio(accountSid, authToken);
+if (!accountSid || !authToken || !verifySid) {
+  console.warn('Twilio environment variables missing; SMS features may not work');
+}
 
 const userStore = require('./userStore');
 const institutionStore = require('./institutionStore');
@@ -315,4 +318,6 @@ wss.on('connection', (ws, req) => {
  });
 
 const PORT = process.env.PORT || 3000;
-server.listen(PORT);
+server.listen(PORT, () => {
+  console.log('Server listening on port', PORT);
+});


### PR DESCRIPTION
## Summary
- add console logs in the frontend `showWorkforce` function to debug applicant fetching
- add warning for missing Twilio environment variables and log server start
- log applicant generation on the backend

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_683fa135db108329a6e6b5a727b0860d