### PR TITLE
Add resource breakdown popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,33 @@
       <button id="weapons-tab-btn">Weapon Catalogue</button>
     </div>
   </div>
+  <!-- Resource Breakdown Popup -->
+  <div id="resource-breakdown-popup" class="panel resource-popup" style="display:none;">
+    <div id="breakdown-close" class="popup-close">×</div>
+    <h2>Resource Breakdown</h2>
+
+    <!-- Aggregated Overview -->
+    <div class="breakdown-section">
+      <h3>Net Resource Flow</h3>
+      <div id="net-flow-container" class="net-flow-grid">
+        <!-- Will be populated dynamically -->
+      </div>
+    </div>
+
+    <!-- Detailed Breakdown -->
+    <div class="breakdown-section">
+      <h3>Top Producers & Consumers</h3>
+      <div id="breakdown-tabs" class="breakdown-tabs">
+        <button class="tab-btn active" data-resource="hydration">💧 Hydration</button>
+        <button class="tab-btn" data-resource="oxygen">🌬️ Oxygen</button>
+        <button class="tab-btn" data-resource="health">❤️ Health</button>
+        <button class="tab-btn" data-resource="money">💰 Money</button>
+      </div>
+      <div id="breakdown-details" class="breakdown-details">
+        <!-- Will be populated dynamically -->
+      </div>
+    </div>
+  </div>
   <div id="partner-form" class="panel" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);padding:10px;gap:4px;flex-direction:column;">
     <label>Total Shares <input id="partner-total" type="number" value="10" min="1"></label>
     <label>Share Price <input id="partner-price" type="number" value="10" min="1"></label>
@@ -336,6 +363,228 @@ const icons = {
   hydrationImg.dataset.current = icons.hydration_full;
   oxygenImg.src = icons.oxygen_full;
   oxygenImg.dataset.current = icons.oxygen_full;
+
+  // Resource tracking system
+  const resourceTracking = {
+    sources: {
+      institutions: new Map(), // id -> { name, owner, effects }
+      workforce: new Map(),    // id:workerIndex -> { name, institutionId, effects }
+      activity: { hydration: 0, oxygen: 0, health: 0, money: 0 },
+      proposals: new Map()     // placeholder for future use
+    },
+
+    trackActivity(hydrationRate, oxygenRate) {
+      this.sources.activity.hydration = -hydrationRate;
+      this.sources.activity.oxygen = -oxygenRate;
+    },
+
+    updateInstitution(id, name, owner, effects, share) {
+      const factor = share || 1;
+      const scaledEffects = {};
+      for (const [key, value] of Object.entries(effects)) {
+        scaledEffects[key] = value * factor;
+      }
+      this.sources.institutions.set(id, { name, owner, effects: scaledEffects });
+    },
+
+    updateWorkforce(institutionId, workerIndex, worker) {
+      const key = `${institutionId}:${workerIndex}`;
+      this.sources.workforce.set(key, {
+        name: worker.name,
+        role: worker.role,
+        institutionId,
+        effects: worker.effects || {}
+      });
+    },
+
+    calculateRates() {
+      const rates = {
+        hydration: { total: 0, producers: [], consumers: [] },
+        oxygen: { total: 0, producers: [], consumers: [] },
+        health: { total: 0, producers: [], consumers: [] },
+        money: { total: 0, producers: [], consumers: [] }
+      };
+
+      this.sources.institutions.forEach((inst, id) => {
+        for (const [resource, value] of Object.entries(inst.effects)) {
+          if (typeof value === 'number' && value !== 0) {
+            rates[resource].total += value;
+            const item = {
+              name: inst.name,
+              source: `Institution (${inst.owner})`,
+              value: value,
+              id: id
+            };
+            if (value > 0) rates[resource].producers.push(item);
+            else rates[resource].consumers.push(item);
+          }
+        }
+      });
+
+      this.sources.workforce.forEach((worker, key) => {
+        for (const [resource, value] of Object.entries(worker.effects)) {
+          if (typeof value === 'number' && value !== 0) {
+            rates[resource].total += value;
+            const inst = institutionDataMap[worker.institutionId];
+            const item = {
+              name: `${worker.name} (${worker.role})`,
+              source: inst ? inst.name : 'Unknown',
+              value: value,
+              id: key
+            };
+            if (value > 0) rates[resource].producers.push(item);
+            else rates[resource].consumers.push(item);
+          }
+        }
+      });
+
+      for (const [resource, value] of Object.entries(this.sources.activity)) {
+        if (value !== 0) {
+          rates[resource].total += value;
+          const item = {
+            name: 'Character Activity',
+            source: isRunning ? 'Running' : isMovingForward ? 'Walking' : 'Idle',
+            value: value
+          };
+          if (value > 0) rates[resource].producers.push(item);
+          else rates[resource].consumers.push(item);
+        }
+      }
+
+      for (const resource of ['hydration', 'oxygen', 'health', 'money']) {
+        rates[resource].producers.sort((a, b) => b.value - a.value).splice(10);
+        rates[resource].consumers.sort((a, b) => a.value - b.value).splice(10);
+      }
+
+      return rates;
+    }
+  };
+
+  function updateResourceTracking() {
+    resourceTracking.sources.institutions.clear();
+    resourceTracking.sources.workforce.clear();
+
+    ownedInstitutions.forEach(inst => {
+      const instData = institutionDataMap[inst.id];
+      if (instData && !instData.destroyed) {
+        const share = inst.factor || 1;
+        const effects = {};
+        ['hydration', 'oxygen', 'health', 'money'].forEach(k => {
+          if (typeof inst[k] === 'number') effects[k] = inst[k];
+        });
+        resourceTracking.updateInstitution(
+          inst.id,
+          instData.name,
+          instData.owner,
+          effects,
+          share
+        );
+      }
+    });
+
+    Object.values(institutionDataMap).forEach(inst => {
+      if (inst.owner === playerEmail && Array.isArray(inst.workforce)) {
+        inst.workforce.forEach((worker, idx) => {
+          if (worker.effects) resourceTracking.updateWorkforce(inst.id, idx, worker);
+        });
+      }
+    });
+
+    const hydrationRate = isMovingForward ? (isRunning ? 0.05 : 0.05) : 0.02;
+    const oxygenRate = isMovingForward ? 0.02 : 0.005;
+    resourceTracking.trackActivity(hydrationRate, oxygenRate);
+  }
+
+  function showResourceBreakdown() {
+    updateResourceTracking();
+    const rates = resourceTracking.calculateRates();
+
+    const netFlowContainer = document.getElementById('net-flow-container');
+    netFlowContainer.innerHTML = '';
+
+    const resourceInfo = {
+      hydration: { icon: '💧', name: 'Hydration' },
+      oxygen: { icon: '🌬️', name: 'Oxygen' },
+      health: { icon: '❤️', name: 'Health' },
+      money: { icon: '💰', name: 'Money' }
+    };
+
+    for (const [resource, info] of Object.entries(resourceInfo)) {
+      const rate = rates[resource];
+      const card = document.createElement('div');
+      card.className = 'resource-flow-card';
+
+      const flowClass = rate.total > 0 ? 'flow-positive' : rate.total < 0 ? 'flow-negative' : 'flow-neutral';
+      const sign = rate.total > 0 ? '+' : '';
+
+      card.innerHTML = `
+        <h4>${info.icon} ${info.name}</h4>
+        <div class="flow-value ${flowClass}">${sign}${rate.total.toFixed(2)}/cycle</div>
+        <div class="flow-breakdown">
+          <div>Producers: ${rate.producers.length}</div>
+          <div>Consumers: ${rate.consumers.length}</div>
+        </div>
+      `;
+
+      netFlowContainer.appendChild(card);
+    }
+
+    showResourceDetails('hydration');
+
+    document.getElementById('resource-breakdown-popup').style.display = 'block';
+  }
+
+  function showResourceDetails(resource) {
+    updateResourceTracking();
+    const rates = resourceTracking.calculateRates();
+    const data = rates[resource];
+
+    const detailsContainer = document.getElementById('breakdown-details');
+    detailsContainer.innerHTML = `
+      <div class="producers-list">
+        <h4>Top Producers</h4>
+        ${data.producers.map(item => `
+          <div class="breakdown-item">
+            <span class="breakdown-item-name">
+              ${item.name}
+              <span class="breakdown-item-source">${item.source}</span>
+            </span>
+            <span class="breakdown-item-value flow-positive">+${item.value.toFixed(2)}</span>
+          </div>
+        `).join('') || '<div class="breakdown-item">None</div>'}
+      </div>
+      <div class="consumers-list">
+        <h4>Top Consumers</h4>
+        ${data.consumers.map(item => `
+          <div class="breakdown-item">
+            <span class="breakdown-item-name">
+              ${item.name}
+              <span class="breakdown-item-source">${item.source}</span>
+            </span>
+            <span class="breakdown-item-value flow-negative">${item.value.toFixed(2)}</span>
+          </div>
+        `).join('') || '<div class="breakdown-item">None</div>'}
+      </div>
+    `;
+
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.resource === resource);
+    });
+  }
+
+  document.getElementById('status-panel').addEventListener('click', showResourceBreakdown);
+
+  document.getElementById('breakdown-close').addEventListener('click', () => {
+    document.getElementById('resource-breakdown-popup').style.display = 'none';
+  });
+
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      showResourceDetails(btn.dataset.resource);
+    });
+  });
+
+  setInterval(updateResourceTracking, 5000);
 
   function fadeSwap(img, src) {
     if (img.dataset.current === src) return;
@@ -876,6 +1125,9 @@ if (window.location.protocol === 'https:') {
   }
 
   function applyInstitutionEffects() {
+    // First update tracking
+    updateResourceTracking();
+
     ownedInstitutions.forEach(e => {
       if (!e || typeof e !== 'object') return;
       const f = e.factor || 1;

--- a/index.html
+++ b/index.html
@@ -379,12 +379,19 @@ const icons = {
     },
 
     updateInstitution(id, name, owner, effects, share) {
-      const factor = share || 1;
+      const factor = share == null ? 1 : share;
       const scaledEffects = {};
       for (const [key, value] of Object.entries(effects)) {
         scaledEffects[key] = value * factor;
       }
-      this.sources.institutions.set(id, { name, owner, effects: scaledEffects });
+      if (this.sources.institutions.has(id)) {
+        const existing = this.sources.institutions.get(id);
+        for (const [k, val] of Object.entries(scaledEffects)) {
+          existing.effects[k] = (existing.effects[k] || 0) + val;
+        }
+      } else {
+        this.sources.institutions.set(id, { name, owner, effects: scaledEffects });
+      }
     },
 
     updateWorkforce(institutionId, workerIndex, worker) {
@@ -1130,7 +1137,7 @@ if (window.location.protocol === 'https:') {
 
     ownedInstitutions.forEach(e => {
       if (!e || typeof e !== 'object') return;
-      const f = e.factor || 1;
+      const f = e.factor == null ? 1 : e.factor;
       if (typeof e.hydration === 'number') hydration = Math.min(hydration + e.hydration * f, 1000);
       if (typeof e.oxygen === 'number') oxygen = Math.min(oxygen + e.oxygen * f, 1000);
       if (typeof e.health === 'number') health = Math.min(health + e.health * f, 1000);

--- a/style.css
+++ b/style.css
@@ -502,3 +502,158 @@ canvas { display: block; width: 100%; height: 100%; }
   box-shadow: 0 4px 12px rgba(244, 67, 54, 0.4);
 }
 
+/* Resource Breakdown Popup */
+.resource-popup {
+  display: none;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 600px;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 24px;
+  z-index: 1000;
+}
+
+.resource-popup h2 {
+  color: #fff;
+  margin: 0 0 20px 0;
+  font-size: 24px;
+}
+
+.resource-popup h3 {
+  color: #fff;
+  margin: 0 0 12px 0;
+  font-size: 18px;
+}
+
+.breakdown-section {
+  margin-bottom: 24px;
+}
+
+.net-flow-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.resource-flow-card {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.resource-flow-card h4 {
+  margin: 0 0 8px 0;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.flow-value {
+  font-size: 24px;
+  font-weight: bold;
+  margin: 4px 0;
+}
+
+.flow-positive {
+  color: #4CAF50;
+}
+
+.flow-negative {
+  color: #f44336;
+}
+
+.flow-neutral {
+  color: #fff;
+}
+
+.flow-breakdown {
+  font-size: 12px;
+  color: #aaa;
+}
+
+.breakdown-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.tab-btn {
+  padding: 8px 16px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #fff;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: all 0.3s;
+}
+
+.tab-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.tab-btn.active {
+  background: rgba(255, 255, 255, 0.3);
+  border-color: #fff;
+}
+
+.breakdown-details {
+  display: flex;
+  gap: 20px;
+}
+
+.producers-list,
+.consumers-list {
+  flex: 1;
+}
+
+.producers-list h4,
+.consumers-list h4 {
+  color: #fff;
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.breakdown-item {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  border-radius: 4px;
+  font-size: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.breakdown-item-name {
+  flex: 1;
+  color: #fff;
+}
+
+.breakdown-item-source {
+  font-size: 11px;
+  color: #888;
+  margin-left: 8px;
+}
+
+.breakdown-item-value {
+  font-weight: bold;
+  margin-left: 8px;
+}
+
+/* Make status panel clickable */
+#status-panel {
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+#status-panel:hover {
+  background: rgba(0, 0, 0, 0.5);
+}
+


### PR DESCRIPTION
## Summary
- add popup markup for resource flow breakdown
- style the new popup and make status panel clickable
- implement resource tracking system and UI logic in JS
- track resource updates when applying institution effects

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fb4b38d4883298fd6c042756f0165