### PR TITLE
Add Planet Hall feature

### DIFF
--- a/api/planetHall.js
+++ b/api/planetHall.js
@@ -1,0 +1,73 @@
+const express = require('express');
+const planetHallStore = require('../planetHallStore');
+const hallChatManager = require('../hallChatManager');
+const referendumManager = require('../referendumManager');
+const userStore = require('../userStore');
+
+module.exports = function(broadcast) {
+  const router = express.Router();
+
+  router.get('/data', (req, res) => {
+    res.json(planetHallStore.getHallData());
+  });
+
+  router.get('/board', (req, res) => {
+    const hall = planetHallStore.getHallData();
+    res.json({ boardMembers: hall.boardMembers });
+  });
+
+  router.get('/chat', (req, res) => {
+    const messages = hallChatManager.getMessages();
+    res.json({ messages });
+  });
+
+  router.post('/chat', (req, res) => {
+    const { email, text } = req.body;
+    if (!email || !text) return res.status(400).json({ error: 'email and text required' });
+    const users = userStore.loadUsers();
+    const user = users[email];
+    if (!user) return res.status(404).json({ error: 'user not found' });
+    const message = hallChatManager.addMessage(email, email, text);
+    broadcast({ type: 'hallChat', message });
+    res.json({ ok: true });
+  });
+
+  router.get('/policies', (req, res) => {
+    const policies = planetHallStore.getPolicies();
+    res.json({ policies });
+  });
+
+  router.post('/policies', (req, res) => {
+    const { email, title, description } = req.body;
+    if (!planetHallStore.isBoardMember(email)) {
+      return res.status(403).json({ error: 'not a board member' });
+    }
+    const policy = planetHallStore.createPolicy(title, description, email);
+    broadcast({ type: 'newPolicy', policy });
+    res.json({ policy });
+  });
+
+  router.post('/policies/:id/vote', (req, res) => {
+    const id = Number(req.params.id);
+    const { email, vote } = req.body;
+    const policy = planetHallStore.votePolicy(id, email, vote);
+    if (!policy) return res.status(400).json({ error: 'invalid vote' });
+    broadcast({ type: 'policyVote', policy });
+    res.json({ policy });
+  });
+
+  router.get('/referendum', (req, res) => {
+    res.json({
+      active: referendumManager.getActiveReferendum(),
+      history: referendumManager.getReferendumHistory()
+    });
+  });
+
+  router.post('/referendum', (req, res) => {
+    const { type, data, email } = req.body;
+    const ref = referendumManager.createReferendum(type, data, email);
+    res.json({ referendum: ref });
+  });
+
+  return router;
+};

--- a/hallChatManager.js
+++ b/hallChatManager.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+
+const FILE = path.join(__dirname, 'hallChat.json');
+const MAX_MESSAGES = 100;
+
+class HallChatManager {
+  constructor() {
+    this.messages = this._load();
+  }
+
+  _load() {
+    try {
+      return JSON.parse(fs.readFileSync(FILE, 'utf8'));
+    } catch {
+      return [];
+    }
+  }
+
+  _save() {
+    fs.writeFileSync(FILE, JSON.stringify(this.messages, null, 2));
+  }
+
+  addMessage(email, name, text) {
+    const message = {
+      email,
+      name,
+      text,
+      timestamp: new Date().toISOString()
+    };
+    this.messages.push(message);
+    if (this.messages.length > MAX_MESSAGES) {
+      this.messages = this.messages.slice(-MAX_MESSAGES);
+    }
+    this._save();
+    return message;
+  }
+
+  getMessages(limit = 50) {
+    return this.messages.slice(-limit);
+  }
+}
+
+module.exports = new HallChatManager();

--- a/index.html
+++ b/index.html
@@ -148,6 +148,40 @@
       </div>
     </div>
   </div>
+
+  <div id="planethall-popup" class="panel" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:700px;max-height:80vh;padding:20px;">
+    <div id="planethall-close" style="cursor:pointer;position:absolute;top:10px;right:10px;font-size:20px;">✕</div>
+    <h2 style="text-align:center;margin-bottom:20px;">Mars Planet Hall</h2>
+    <div class="planethall-tabs">
+      <button class="hall-tab active" data-section="board">Governing Board</button>
+      <button class="hall-tab" data-section="referendum">Referendum</button>
+      <button class="hall-tab" data-section="chat">Public Chat</button>
+      <button class="hall-tab" data-section="policies">Policies</button>
+    </div>
+    <div id="hall-board" class="hall-section">
+      <h3>Mars Governing Board</h3>
+      <div id="board-members"></div>
+    </div>
+    <div id="hall-referendum" class="hall-section" style="display:none;">
+      <h3>Referendum</h3>
+      <button id="request-referendum">Request Referendum</button>
+      <div id="active-referendum"></div>
+      <div id="referendum-history"></div>
+    </div>
+    <div id="hall-chat" class="hall-section" style="display:none;">
+      <h3>Public Chat</h3>
+      <div id="hall-chat-messages"></div>
+      <div style="display:flex;gap:4px;margin-top:8px;">
+        <input id="hall-chat-input" type="text" style="flex:1;padding:4px;" placeholder="Type message...">
+        <button id="hall-chat-send">Send</button>
+      </div>
+    </div>
+    <div id="hall-policies" class="hall-section" style="display:none;">
+      <h3>Policies</h3>
+      <button id="new-policy-btn" style="display:none;">New Policy</button>
+      <div id="policies-list"></div>
+    </div>
+  </div>
   <script type="module">
 
   const DEBUG_LOG = true;
@@ -786,6 +820,16 @@ function updateStatImages() {
       price: 300,
       effects: {},
       animated: false
+    },
+    {
+      name: 'Planet Hall',
+      url: 'planethall.glb',
+      thumbnail: 'planethall.png',
+      scale: 1.5,
+      price: 0,
+      effects: {},
+      animated: false,
+      isPlanetHall: true
     }
   ];
 
@@ -1047,7 +1091,9 @@ if (window.location.protocol === 'https:') {
         const id = obj.userData.institutionId;
         const data = institutionDataMap[id];
         if (data && !data.destroyed) {
-          if (data.funded === false) {
+          if (data.isPlanetHall) {
+            showPlanetHallPopup();
+          } else if (data.funded === false) {
             openBuySharesForm(data);
           } else {
             showInstitutionPopup(id);
@@ -1462,6 +1508,10 @@ if (window.location.protocol === 'https:') {
         updateMoneyDisplay();
       } else if (msg.type === 'flag') {
         createFlag(msg.id, msg.position);
+      } else if (msg.type === 'hallChat') {
+        loadHallChat();
+      } else if (msg.type === 'newPolicy' || msg.type === 'policyVote') {
+        loadPolicies();
       } else if (msg.type === 'respawn') {
   dead = false;
   deathOverlay.style.display = 'none';
@@ -3791,7 +3841,127 @@ function showWorkerProfile(worker, institutionId, isHired = false, index = null)
     }
 
     // Render using composer for bloom effect
-    composer.render();
+  composer.render();
+}
+
+// Planet Hall functionality
+let currentBoardMembers = [];
+
+function showPlanetHallPopup() {
+  const popup = document.getElementById('planethall-popup');
+  popup.style.display = 'block';
+  loadBoardMembers();
+  loadHallChat();
+  loadPolicies();
+  loadReferendum();
+}
+
+async function loadBoardMembers() {
+  try {
+    const res = await fetch('/api/planethall/board');
+    const data = await res.json();
+    currentBoardMembers = data.boardMembers || [];
+    const container = document.getElementById('board-members');
+    container.innerHTML = '';
+    if (currentBoardMembers.length === 0) {
+      container.innerHTML = '<div style="color:#888;">No board members elected yet</div>';
+      return;
+    }
+    currentBoardMembers.forEach(m => {
+      const div = document.createElement('div');
+      div.className = 'board-member';
+      div.innerHTML = `<div style="font-weight:bold;">${m.name}</div><div style="font-size:12px;color:#888;">Elected: ${new Date(m.electedDate).toLocaleDateString()}</div>`;
+      container.appendChild(div);
+    });
+    const isMember = currentBoardMembers.some(m => m.email === playerEmail);
+    document.getElementById('new-policy-btn').style.display = isMember ? 'block' : 'none';
+  } catch (err) {
+    console.error('Failed to load board members', err);
+  }
+}
+
+async function loadHallChat() {
+  try {
+    const res = await fetch('/api/planethall/chat');
+    const data = await res.json();
+    const container = document.getElementById('hall-chat-messages');
+    container.innerHTML = '';
+    data.messages.forEach(m => {
+      const div = document.createElement('div');
+      div.className = 'hall-chat-message';
+      div.innerHTML = `<strong>${m.name}:</strong> ${m.text}`;
+      container.appendChild(div);
+    });
+    container.scrollTop = container.scrollHeight;
+  } catch (err) {
+    console.error('Failed to load chat', err);
+  }
+}
+
+async function loadPolicies() {
+  try {
+    const res = await fetch('/api/planethall/policies');
+    const data = await res.json();
+    const container = document.getElementById('policies-list');
+    container.innerHTML = '';
+    data.policies.forEach(p => {
+      const div = document.createElement('div');
+      div.className = 'policy-item';
+      let color = '#888';
+      if (p.status === 'approved') color = '#4CAF50';
+      else if (p.status === 'rejected') color = '#f44336';
+      div.innerHTML = `<div style="font-weight:bold;">${p.title}</div><div style="font-size:12px;margin:4px 0;">${p.description}</div><div style="font-size:11px;color:#888;">Proposed by: ${p.proposedBy}</div><div style="font-size:11px;color:${color};">Status: ${p.status}</div>`;
+      const isMember = currentBoardMembers.some(m => m.email === playerEmail);
+      if (isMember && p.status === 'voting' && !p.votes[playerEmail]) {
+        const voteDiv = document.createElement('div');
+        voteDiv.style.marginTop = '8px';
+        voteDiv.innerHTML = `<button onclick="votePolicy(${p.id}, true)">Approve</button> <button onclick="votePolicy(${p.id}, false)">Reject</button>`;
+        div.appendChild(voteDiv);
+      }
+      container.appendChild(div);
+    });
+  } catch (err) {
+    console.error('Failed to load policies', err);
+  }
+}
+
+async function loadReferendum() {
+  document.getElementById('active-referendum').innerHTML = '<div style="color:#888;">No active referendum</div>';
+  document.getElementById('referendum-history').innerHTML = '<div style="color:#888;">No referendum history</div>';
+}
+
+document.getElementById('planethall-close').onclick = () => {
+  document.getElementById('planethall-popup').style.display = 'none';
+};
+
+document.querySelectorAll('.hall-tab').forEach(tab => {
+  tab.onclick = () => {
+    document.querySelectorAll('.hall-tab').forEach(t => t.classList.remove('active'));
+    tab.classList.add('active');
+    document.querySelectorAll('.hall-section').forEach(s => s.style.display = 'none');
+    document.getElementById(`hall-${tab.dataset.section}`).style.display = 'block';
+  };
+});
+
+document.getElementById('hall-chat-send').onclick = async () => {
+  const input = document.getElementById('hall-chat-input');
+  const text = input.value.trim();
+  if (!text) return;
+  try {
+    await fetch('/api/planethall/chat', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email: playerEmail, text }) });
+    input.value = '';
+  } catch (err) {
+    console.error('Failed to send chat', err);
+  }
+};
+
+async function votePolicy(id, vote) {
+  try {
+    await fetch(`/api/planethall/policies/${id}/vote`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email: playerEmail, vote }) });
+    loadPolicies();
+  } catch (err) {
+    console.error('Failed to vote', err);
+  }
 }
 
   // Start the game loop after login

--- a/planetHallStore.js
+++ b/planetHallStore.js
@@ -1,0 +1,116 @@
+const fs = require('fs');
+const path = require('path');
+
+const FILE = path.join(__dirname, 'planetHall.json');
+
+class PlanetHallStore {
+  constructor() {
+    this.data = this._load();
+    this._ensureStructure();
+  }
+
+  _load() {
+    try {
+      return JSON.parse(fs.readFileSync(FILE, 'utf8'));
+    } catch {
+      return this._getDefaultData();
+    }
+  }
+
+  _getDefaultData() {
+    return {
+      id: 999999,
+      position: [0, 0, 0],
+      boardMembers: [],
+      policies: [],
+      nextPolicyId: 1
+    };
+  }
+
+  _ensureStructure() {
+    if (!this.data.boardMembers) this.data.boardMembers = [];
+    if (!this.data.policies) this.data.policies = [];
+    if (!this.data.nextPolicyId) this.data.nextPolicyId = 1;
+    this._save();
+  }
+
+  _save() {
+    fs.writeFileSync(FILE, JSON.stringify(this.data, null, 2));
+  }
+
+  getHallData() {
+    return { ...this.data };
+  }
+
+  updatePosition(position) {
+    this.data.position = position;
+    this._save();
+  }
+
+  addBoardMember(email, name) {
+    if (this.data.boardMembers.length >= 5) return false;
+    if (this.data.boardMembers.find(m => m.email === email)) return false;
+    this.data.boardMembers.push({
+      email,
+      name,
+      electedDate: new Date().toISOString()
+    });
+    this._save();
+    return true;
+  }
+
+  removeBoardMember(email) {
+    const index = this.data.boardMembers.findIndex(m => m.email === email);
+    if (index === -1) return false;
+    this.data.boardMembers.splice(index, 1);
+    this._save();
+    return true;
+  }
+
+  isBoardMember(email) {
+    return this.data.boardMembers.some(m => m.email === email);
+  }
+
+  createPolicy(title, description, proposedBy) {
+    const policy = {
+      id: this.data.nextPolicyId++,
+      title,
+      description,
+      proposedBy,
+      votes: {},
+      status: 'voting',
+      createdDate: new Date().toISOString()
+    };
+    this.data.policies.push(policy);
+    this._save();
+    return policy;
+  }
+
+  votePolicy(policyId, email, vote) {
+    const policy = this.data.policies.find(p => p.id === policyId);
+    if (!policy || policy.status !== 'voting') return null;
+    if (!this.isBoardMember(email)) return null;
+
+    policy.votes[email] = vote;
+
+    const boardCount = this.data.boardMembers.length;
+    const yesVotes = Object.values(policy.votes).filter(v => v).length;
+    const noVotes = Object.values(policy.votes).filter(v => !v).length;
+
+    if (yesVotes > boardCount / 2) {
+      policy.status = 'approved';
+      policy.approvedDate = new Date().toISOString();
+    } else if (noVotes >= boardCount / 2) {
+      policy.status = 'rejected';
+    }
+
+    this._save();
+    return policy;
+  }
+
+  getPolicies() {
+    return [...this.data.policies];
+  }
+}
+
+module.exports = new PlanetHallStore();

--- a/referendumManager.js
+++ b/referendumManager.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+
+const FILE = path.join(__dirname, 'referendums.json');
+
+class ReferendumManager {
+  constructor() {
+    this.data = this._load();
+  }
+
+  _load() {
+    try {
+      return JSON.parse(fs.readFileSync(FILE, 'utf8'));
+    } catch {
+      return {
+        active: null,
+        history: [],
+        nextId: 1
+      };
+    }
+  }
+
+  _save() {
+    fs.writeFileSync(FILE, JSON.stringify(this.data, null, 2));
+  }
+
+  createReferendum(type, data, proposedBy) {
+    console.log('Creating referendum:', { type, data, proposedBy });
+    const ref = { id: this.data.nextId++, type, data, proposedBy, status: 'pending' };
+    this.data.active = ref;
+    this._save();
+    return ref;
+  }
+
+  getActiveReferendum() {
+    return this.data.active;
+  }
+
+  getReferendumHistory() {
+    return this.data.history;
+  }
+}
+
+module.exports = new ReferendumManager();

--- a/style.css
+++ b/style.css
@@ -657,3 +657,65 @@ canvas { display: block; width: 100%; height: 100%; }
   background: rgba(0, 0, 0, 0.5);
 }
 
+.planethall-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #444;
+}
+
+.hall-tab {
+  padding: 8px 16px;
+  background: transparent;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.hall-tab.active {
+  border-bottom-color: #4CAF50;
+}
+
+.hall-section {
+  min-height: 300px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+#board-members {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.board-member {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 12px;
+  border-radius: 4px;
+}
+
+#hall-chat-messages {
+  height: 300px;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 8px;
+  border-radius: 4px;
+}
+
+.hall-chat-message {
+  margin-bottom: 8px;
+  padding: 4px;
+}
+
+#policies-list {
+  margin-top: 12px;
+}
+
+.policy-item {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 12px;
+  margin-bottom: 8px;
+  border-radius: 4px;
+}
+


### PR DESCRIPTION
## Summary
- implement persistent store for Planet Hall
- implement hall chat and referendum placeholders
- expose new `/api/planethall` API routes
- show Planet Hall in the game UI and add popup with board, chat and policies
- integrate Planet Hall into server's institution list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684173fb454483299b0d74bf603144dc