### PR TITLE
Implement AI-powered referendums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ chatLogs.json
 defence_base.json
 institutions.json
 users.json
+!referendums.json
 earthquake.png
 dangerousChemicals.png
 earthquake.png

--- a/api/planetHall.js
+++ b/api/planetHall.js
@@ -2,6 +2,7 @@ const express = require('express');
 const planetHallStore = require('../planetHallStore');
 const hallChatManager = require('../hallChatManager');
 const referendumManager = require('../referendumManager');
+const referendumService = require('../referendumService');
 const userStore = require('../userStore');
 
 module.exports = function(broadcast) {
@@ -63,10 +64,14 @@ module.exports = function(broadcast) {
     });
   });
 
-  router.post('/referendum', (req, res) => {
+  router.post('/referendum', async (req, res) => {
     const { type, data, email } = req.body;
-    const ref = referendumManager.createReferendum(type, data, email);
-    res.json({ referendum: ref });
+    try {
+      const ref = await referendumService.runReferendum(type, data, email, broadcast);
+      res.json({ referendum: ref });
+    } catch (err) {
+      res.status(500).json({ error: 'failed' });
+    }
   });
 
   return router;

--- a/index.html
+++ b/index.html
@@ -114,6 +114,24 @@
     <label>My Shares <input id="partner-my" type="number" value="1" min="1"></label>
     <button id="partner-save">Save</button>
   </div>
+  <div id="referendum-form" class="panel" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);padding:10px;gap:6px;flex-direction:column;">
+    <select id="referendum-type">
+      <option value="candidate">Board Candidate</option>
+      <option value="fire">Remove Board Member</option>
+      <option value="policy">Open Policy</option>
+    </select>
+    <div id="candidate-fields">
+      <input id="candidate-email" type="text" placeholder="Candidate Email">
+      <input id="candidate-name" type="text" placeholder="Candidate Name">
+    </div>
+    <div id="fire-fields" style="display:none;">
+      <select id="fire-email"></select>
+    </div>
+    <div id="policy-fields" style="display:none;">
+      <input id="policy-text" type="text" placeholder="Policy Text">
+    </div>
+    <button id="referendum-submit">Submit</button>
+  </div>
   <div id="worker-profile-overlay" class="worker-profile-overlay hidden">
     <div class="worker-profile">
       <div class="profile-close" id="profile-close">×</div>
@@ -968,6 +986,29 @@ if (window.location.protocol === 'https:') {
     };
   }
 
+  function openReferendumForm() {
+    const form = document.getElementById('referendum-form');
+    form.style.display = 'flex';
+    updateReferendumFields();
+  }
+
+  function updateReferendumFields() {
+    const type = document.getElementById('referendum-type').value;
+    document.getElementById('candidate-fields').style.display = type === 'candidate' ? 'block' : 'none';
+    document.getElementById('fire-fields').style.display = type === 'fire' ? 'block' : 'none';
+    document.getElementById('policy-fields').style.display = type === 'policy' ? 'block' : 'none';
+    if (type === 'fire') {
+      const sel = document.getElementById('fire-email');
+      sel.innerHTML = '';
+      currentBoardMembers.forEach(m => {
+        const opt = document.createElement('option');
+        opt.value = m.email;
+        opt.textContent = m.name;
+        sel.appendChild(opt);
+      });
+    }
+  }
+
   let ghostInstitution = null;
   let ghostMixer = null;
   let placingInstitution = false;
@@ -1514,6 +1555,12 @@ if (window.location.protocol === 'https:') {
         loadHallChat();
       } else if (msg.type === 'newPolicy' || msg.type === 'policyVote') {
         loadPolicies();
+      } else if (
+        msg.type === 'referendumStart' ||
+        msg.type === 'referendumProgress' ||
+        msg.type === 'referendumResult'
+      ) {
+        loadReferendum();
       } else if (msg.type === 'respawn') {
   dead = false;
   deathOverlay.style.display = 'none';
@@ -3928,8 +3975,34 @@ async function loadPolicies() {
 }
 
 async function loadReferendum() {
-  document.getElementById('active-referendum').innerHTML = '<div style="color:#888;">No active referendum</div>';
-  document.getElementById('referendum-history').innerHTML = '<div style="color:#888;">No referendum history</div>';
+  try {
+    const res = await fetch('/api/planethall/referendum');
+    const data = await res.json();
+    const activeDiv = document.getElementById('active-referendum');
+    const histDiv = document.getElementById('referendum-history');
+    activeDiv.innerHTML = '';
+    histDiv.innerHTML = '';
+    if (data.active) {
+      const yes = Object.values(data.active.votes || {}).filter(v => v).length;
+      const no = Object.values(data.active.votes || {}).filter(v => !v).length;
+      const total = data.active.totalWorkers || yes + no;
+      activeDiv.innerHTML = `<div>Type: ${data.active.type}</div><div>Votes: ${yes+no}/${total}</div><div>Status: ${data.active.status}</div>`;
+    } else {
+      activeDiv.innerHTML = '<div style="color:#888;">No active referendum</div>';
+    }
+    if (Array.isArray(data.history) && data.history.length > 0) {
+      data.history.slice(-5).forEach(r => {
+        const d = document.createElement('div');
+        d.style.marginTop = '6px';
+        d.textContent = `${r.type} - ${r.status} (${r.result?.yes||0}/${r.result?.no||0})`;
+        histDiv.appendChild(d);
+      });
+    } else {
+      histDiv.innerHTML = '<div style="color:#888;">No referendum history</div>';
+    }
+  } catch (err) {
+    document.getElementById('active-referendum').innerHTML = '<div style="color:#888;">Failed to load</div>';
+  }
 }
 
 document.getElementById('planethall-close').onclick = () => {
@@ -3944,6 +4017,34 @@ document.querySelectorAll('.hall-tab').forEach(tab => {
     document.getElementById(`hall-${tab.dataset.section}`).style.display = 'block';
   };
 });
+
+document.getElementById('request-referendum').onclick = () => {
+  openReferendumForm();
+};
+document.getElementById('referendum-type').onchange = updateReferendumFields;
+document.getElementById('referendum-submit').onclick = async e => {
+  e.stopPropagation();
+  const type = document.getElementById('referendum-type').value;
+  let data = {};
+  if (type === 'candidate') {
+    data.email = document.getElementById('candidate-email').value.trim();
+    data.name = document.getElementById('candidate-name').value.trim();
+  } else if (type === 'fire') {
+    data.email = document.getElementById('fire-email').value;
+  } else {
+    data.text = document.getElementById('policy-text').value.trim();
+  }
+  try {
+    await fetch('/api/planethall/referendum', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type, data, email: playerEmail })
+    });
+    document.getElementById('referendum-form').style.display = 'none';
+  } catch (err) {
+    console.error('Failed to start referendum', err);
+  }
+};
 
 document.getElementById('hall-chat-send').onclick = async () => {
   const input = document.getElementById('hall-chat-input');

--- a/referendumManager.js
+++ b/referendumManager.js
@@ -26,10 +26,27 @@ class ReferendumManager {
 
   createReferendum(type, data, proposedBy) {
     console.log('Creating referendum:', { type, data, proposedBy });
-    const ref = { id: this.data.nextId++, type, data, proposedBy, status: 'pending' };
+    const ref = {
+      id: this.data.nextId++,
+      type,
+      data,
+      proposedBy,
+      status: 'pending'
+    };
     this.data.active = ref;
     this._save();
     return ref;
+  }
+
+  updateActive(ref) {
+    this.data.active = ref;
+    this._save();
+  }
+
+  finalize(ref) {
+    this.data.history.push(ref);
+    this.data.active = null;
+    this._save();
   }
 
   getActiveReferendum() {

--- a/referendumService.js
+++ b/referendumService.js
@@ -1,0 +1,93 @@
+const institutionStore = require('./institutionStore');
+const planetHallStore = require('./planetHallStore');
+const referendumManager = require('./referendumManager');
+
+let OpenAI = null;
+try {
+  OpenAI = require('openai');
+} catch {}
+
+const openai = OpenAI && process.env.OPENAI_API_KEY
+  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  : null;
+
+async function queryVote(worker, owner, question) {
+  if (!openai) {
+    return Math.random() < 0.5 ? 'yes' : 'no';
+  }
+  try {
+    const messages = [
+      { role: 'system', content: 'You are an AI worker voting in a referendum. Always reply with JSON like {"vote":"yes"} or {"vote":"no"}.' },
+      { role: 'user', content: `Owner: ${owner}\nName: ${worker.name}\nRole: ${worker.role}\nResume: ${worker.resume}\nBackstory: ${worker.backstory}\nReferendum: ${question}` }
+    ];
+    const resp = await openai.chat.completions.create({
+      model: 'gpt-4.1-nano-2025-04-14',
+      messages,
+      temperature: 1,
+      max_tokens: 100
+    });
+    const text = resp.choices?.[0]?.message?.content || '';
+    const match = text.match(/\{[\s\S]*\}/);
+    if (match) {
+      try {
+        const obj = JSON.parse(match[0]);
+        const v = String(obj.vote || obj.answer || '').toLowerCase();
+        if (v.includes('yes')) return 'yes';
+        return 'no';
+      } catch {}
+    }
+    return text.toLowerCase().includes('yes') ? 'yes' : 'no';
+  } catch {
+    return Math.random() < 0.5 ? 'yes' : 'no';
+  }
+}
+
+async function runReferendum(type, data, proposedBy, broadcast) {
+  const ref = referendumManager.createReferendum(type, data, proposedBy);
+  const institutions = institutionStore.getInstitutions();
+  const workers = [];
+  institutions.forEach(inst => {
+    if (Array.isArray(inst.workforce)) {
+      inst.workforce.forEach(w => workers.push({ worker: w, owner: inst.owner }));
+    }
+  });
+  ref.totalWorkers = workers.length;
+  ref.votes = {};
+  ref.voted = 0;
+  ref.status = 'voting';
+  referendumManager.updateActive(ref);
+  if (broadcast) {
+    broadcast({ type: 'referendumStart', referendum: { id: ref.id, type: ref.type, total: ref.totalWorkers } });
+  }
+
+  for (const entry of workers) {
+    const vote = await queryVote(entry.worker, entry.owner, JSON.stringify({ type, data }));
+    ref.votes[`${entry.owner}|${entry.worker.name}`] = vote === 'yes';
+    ref.voted++;
+    referendumManager.updateActive(ref);
+    if (broadcast) {
+      broadcast({ type: 'referendumProgress', votes: ref.voted, total: ref.totalWorkers });
+    }
+  }
+
+  const yes = Object.values(ref.votes).filter(v => v).length;
+  const no = Object.values(ref.votes).filter(v => !v).length;
+  ref.result = { yes, no };
+  ref.status = yes > no ? 'approved' : 'rejected';
+
+  if (ref.status === 'approved') {
+    if (type === 'candidate' && data.email && data.name) {
+      planetHallStore.addBoardMember(data.email, data.name);
+    } else if (type === 'fire' && data.email) {
+      planetHallStore.removeBoardMember(data.email);
+    }
+  }
+
+  referendumManager.finalize(ref);
+  if (broadcast) {
+    broadcast({ type: 'referendumResult', referendum: ref });
+  }
+  return ref;
+}
+
+module.exports = { runReferendum };

--- a/referendums.json
+++ b/referendums.json
@@ -1,0 +1,5 @@
+{
+  "active": null,
+  "history": [],
+  "nextId": 1
+}


### PR DESCRIPTION
## Summary
- add referendum voting service that queries AI workers
- track referendums and store history
- expose referendum API using new service
- add UI for starting referendums and viewing progress
- show updates when AI votes are received

## Testing
- `npm start` *(fails: cannot run in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68418665af2083299302234e08895526