### PR TITLE
Implement policy workflow and update AI prompts

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,11 @@
     </div>
     <button id="referendum-submit">Submit</button>
   </div>
+  <div id="policy-form" class="panel" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);padding:10px;gap:6px;flex-direction:column;">
+    <input id="policy-title" type="text" placeholder="Policy Title">
+    <textarea id="policy-desc" placeholder="Policy Description" rows="4" style="width:200px;"></textarea>
+    <button id="policy-save">Save</button>
+  </div>
   <div id="worker-profile-overlay" class="worker-profile-overlay hidden">
     <div class="worker-profile">
       <div class="profile-close" id="profile-close">×</div>
@@ -990,6 +995,13 @@ if (window.location.protocol === 'https:') {
     const form = document.getElementById('referendum-form');
     form.style.display = 'flex';
     updateReferendumFields();
+  }
+
+  function openPolicyForm() {
+    const form = document.getElementById('policy-form');
+    form.style.display = 'flex';
+    document.getElementById('policy-title').value = '';
+    document.getElementById('policy-desc').value = '';
   }
 
   function updateReferendumFields() {
@@ -4021,6 +4033,9 @@ document.querySelectorAll('.hall-tab').forEach(tab => {
 document.getElementById('request-referendum').onclick = () => {
   openReferendumForm();
 };
+document.getElementById('new-policy-btn').onclick = () => {
+  openPolicyForm();
+};
 document.getElementById('referendum-type').onchange = updateReferendumFields;
 document.getElementById('referendum-submit').onclick = async e => {
   e.stopPropagation();
@@ -4046,6 +4061,24 @@ document.getElementById('referendum-submit').onclick = async e => {
   }
 };
 
+document.getElementById('policy-save').onclick = async e => {
+  e.stopPropagation();
+  const title = document.getElementById('policy-title').value.trim();
+  const description = document.getElementById('policy-desc').value.trim();
+  if (!title || !description) return;
+  try {
+    await fetch('/api/planethall/policies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: playerEmail, title, description })
+    });
+    document.getElementById('policy-form').style.display = 'none';
+    loadPolicies();
+  } catch (err) {
+    console.error('Failed to create policy', err);
+  }
+};
+
 document.getElementById('hall-chat-send').onclick = async () => {
   const input = document.getElementById('hall-chat-input');
   const text = input.value.trim();
@@ -4058,7 +4091,7 @@ document.getElementById('hall-chat-send').onclick = async () => {
   }
 };
 
-async function votePolicy(id, vote) {
+window.votePolicy = async function votePolicy(id, vote) {
   try {
     await fetch(`/api/planethall/policies/${id}/vote`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email: playerEmail, vote }) });
     loadPolicies();

--- a/planetHallStore.js
+++ b/planetHallStore.js
@@ -137,6 +137,10 @@ class PlanetHallStore {
   getPolicies() {
     return [...this.data.policies];
   }
+
+  getApprovedPolicies() {
+    return this.data.policies.filter(p => p.status === 'approved');
+  }
 }
 
 module.exports = new PlanetHallStore();


### PR DESCRIPTION
## Summary
- add a form to create policies in Planet Hall
- allow board members to open the new form and submit policies
- include current approved policies when generating worker profiles and judging proposals
- expose `getApprovedPolicies` in `planetHallStore`
- fix policy voting button by exporting `votePolicy` to `window`

## Testing
- `node -e "require('./judge.js');require('./api/workforce.js');require('./planetHallStore');console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_6841a8d3a58883299ba9dd9da39573e4