### PR TITLE
Throttle movement broadcasts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1536,6 +1536,10 @@ if (window.location.protocol === 'https:') {
         createRemotePlayer(msg.id, msg.state);
       } else if (msg.type === 'update') {
         if (msg.id !== clientId) updateRemotePlayer(msg.id, msg);
+      } else if (msg.type === 'batchUpdate') {
+        msg.updates.forEach(update => {
+          if (update.id !== clientId) updateRemotePlayer(update.id, update);
+        });
       } else if (msg.type === 'remove') {
         removeRemotePlayer(msg.id);
       } else if (msg.type === 'addInstitution') {

--- a/stateThrottle.js
+++ b/stateThrottle.js
@@ -1,0 +1,34 @@
+// stateThrottle.js - Efficient state broadcasting
+class StateThrottle {
+  constructor(broadcastFn, interval = 50) { // 20 updates/sec instead of 60+
+    this.broadcast = broadcastFn;
+    this.interval = interval;
+    this.pendingUpdates = new Map(); // playerId -> latest state
+    this.timer = setInterval(() => this.flush(), interval);
+  }
+
+  update(playerId, state) {
+    this.pendingUpdates.set(playerId, { state });
+  }
+
+  flush() {
+    if (this.pendingUpdates.size === 0) return;
+
+    const updates = [];
+    for (const [playerId, { state }] of this.pendingUpdates) {
+      updates.push({ id: playerId, ...state });
+    }
+
+    this.broadcast({ type: 'batchUpdate', updates });
+    this.pendingUpdates.clear();
+  }
+
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+module.exports = StateThrottle;


### PR DESCRIPTION
## Summary
- throttle player state broadcasting with a new `StateThrottle` helper
- batch and throttle movement updates on the server
- handle `batchUpdate` messages on the client

## Testing
- `node -v` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842bb7cd5588329b58ce358c0cb8686