### PR TITLE
Add weapon consumption and rebuild feature

### DIFF
--- a/defenceBaseStore.js
+++ b/defenceBaseStore.js
@@ -77,6 +77,35 @@ function updateWeapon(id, index, updates) {
   return w;
 }
 
+function consumeWeapon(id, index) {
+  let w = null;
+  store.update(data => {
+    const entry = ensure(data, id);
+    w = entry.weapons[index];
+    if (!w) return data;
+    w.consumed = true;
+    console.log('[DEFENCE STORE] consumeWeapon', { id, index });
+    return data;
+  });
+  return w;
+}
+
+function cloneWeapon(id, index) {
+  let weapon = null;
+  let newIdx = null;
+  store.update(data => {
+    const entry = ensure(data, id);
+    const src = entry.weapons[index];
+    if (!src) return data;
+    weapon = { ...src, consumed: false };
+    entry.weapons.push(weapon);
+    newIdx = entry.weapons.length - 1;
+    console.log('[DEFENCE STORE] cloneWeapon', { id, index, newIdx });
+    return data;
+  });
+  return { weapon, index: newIdx };
+}
+
 module.exports = {
   getProposals,
   addProposal,
@@ -84,4 +113,6 @@ module.exports = {
   getWeapons,
   addWeapon,
   updateWeapon,
+  consumeWeapon,
+  cloneWeapon,
 };

--- a/index.html
+++ b/index.html
@@ -1883,7 +1883,7 @@ if (window.location.protocol === 'https:') {
     weaponMap[inst.id] = [];
     if (!Array.isArray(inst.weapons)) return;
     inst.weapons.forEach((w, idx) => {
-      if (!w) return;
+      if (!w || w.consumed) return;
       const offset = Array.isArray(w.offset)
         ? new THREE.Vector3().fromArray(w.offset)
         : new THREE.Vector3(6 + idx * 2, 0, 0);
@@ -1990,7 +1990,7 @@ if (window.location.protocol === 'https:') {
   }
 
   function fireWeapon(entry) {
-    if (!model || !entry || !entry.obj || !entry.data) return;
+    if (!model || !entry || !entry.obj || !entry.data || entry.data.consumed) return;
     const params = entry.data.parameters || {};
     let tech = entry.data.technology;
     if (Array.isArray(tech)) tech = tech[0];
@@ -2047,10 +2047,29 @@ if (window.location.protocol === 'https:') {
         animation: activeAction && activeAction._clip ? activeAction._clip.name : 'none'
       });
     }
+    markWeaponConsumed(entry);
   }
 
   function fireAllWeapons() {
-    Object.values(weaponMap).forEach(arr => arr.forEach(w => fireWeapon(w)));
+    Object.values(weaponMap).forEach(arr =>
+      arr.forEach(w => { if (w && w.data && !w.data.consumed) fireWeapon(w); })
+    );
+  }
+
+  function markWeaponConsumed(entry) {
+    if (!entry || !entry.obj) return;
+    const instId = entry.obj.userData.weaponInstId;
+    const idx = entry.obj.userData.weaponIndex;
+    if (instId === undefined || idx === undefined) return;
+    if (entry.obj.parent) entry.obj.parent.remove(entry.obj);
+    entry.data.consumed = true;
+    if (socket) {
+      fetch(`/api/defence/weapons/consume/${instId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ index: idx })
+      });
+    }
   }
 
   function updateProjectiles(dt) {
@@ -2885,11 +2904,31 @@ async function showWorkforce() {
       if (res.ok) {
         const data = await res.json();
         container.innerHTML = '';
-        (data.weapons || []).forEach(w => {
+        (data.weapons || []).forEach((w, idx) => {
           const div = document.createElement('div');
-          div.textContent = `${w.name} - movement ${w.movement.toFixed(2)}`;
           div.className = 'weapon-entry';
-          div.onclick = () => alert('Using weapon ' + w.name);
+          div.textContent = `${w.name} - movement ${w.movement.toFixed(2)}`;
+          if (w.consumed) {
+            const btn = document.createElement('button');
+            btn.textContent = `Rebuild $${(w.movement * 1000).toFixed(0)}`;
+            btn.onclick = async () => {
+              const res2 = await fetch(`/api/defence/weapons/rebuild/${id}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ index: idx, email: playerEmail })
+              });
+              if (res2.ok) {
+                const d = await res2.json();
+                playerMoney = d.money;
+                updateMoneyDisplay();
+                showWeapons();
+              } else {
+                alert('Failed to rebuild');
+              }
+            };
+            div.appendChild(document.createTextNode(' - consumed '));
+            div.appendChild(btn);
+          }
           container.appendChild(div);
         });
         if (!data.weapons || data.weapons.length === 0) {

--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ function sendToEmail(email, data) {
 }
 
 const workforceRoute = require('./api/workforce')(institutionStore, userStore, engine, broadcast, sendToEmail);
-const defenceRoute = require('./api/defence')(defenceStore, institutionStore, broadcast);
+const defenceRoute = require('./api/defence')(defenceStore, institutionStore, userStore, broadcast, sendToEmail);
 const planetHallRoute = require('./api/planetHall')(broadcast);
 chatManager.initFromInstitutions(institutionStore.getInstitutions());
 


### PR DESCRIPTION
## Summary
- mark weapons as consumed when fired and remove from scene
- support consuming weapons and cloning them in the defence store
- extend defence API to consume and rebuild weapons, costing movement * 1000
- update server to pass user store and send money updates
- update client to skip consumed weapons, rebuild from catalogue, and notify server when firing

## Testing
- `node --check server.js`
- `node --check api/defence.js`
- `node --check defenceBaseStore.js`


------
https://chatgpt.com/codex/tasks/task_e_684563fb95ac8329ae868c484e0cc58c