### PR TITLE
Add job posting input for applicant generation

### DIFF
--- a/api/workforce.js
+++ b/api/workforce.js
@@ -73,7 +73,7 @@ module.exports = function(institutionStore, userStore, engine, broadcast, sendTo
     return worker;
   }
 
-  async function generateWorkerWithAI(institutionName) {
+  async function generateWorkerWithAI(institutionName, job) {
     if (!openai) {
       return randomWorker();
     }
@@ -96,7 +96,7 @@ module.exports = function(institutionStore, userStore, engine, broadcast, sendTo
           content: systemPrompt
         }, {
           role: "user",
-          content: `Generate a  bullet point style, short, worker profile for a Mars colonization game. The worker will be employed at a ${institutionName} facility.
+          content: `Generate a  bullet point style, short, worker profile for a Mars colonization game. The worker will be employed at a ${institutionName} facility.${job && (job.title || job.description) ? ` The position is ${job.title || ''}. ${job.description || ''}` : ''}
 
           Please provide:
           1. A realistic full name
@@ -178,14 +178,14 @@ module.exports = function(institutionStore, userStore, engine, broadcast, sendTo
     }
   }
 
-  async function generateWorkers(num, institutionName = 'Mars Colony') {
+  async function generateWorkers(num, institutionName = 'Mars Colony', job) {
     const workers = [];
 
     // Use Promise.all to generate workers in parallel for better performance
     const workerPromises = [];
     for (let i = 0; i < num; i++) {
       if (openai) {
-        workerPromises.push(generateWorkerWithAI(institutionName));
+        workerPromises.push(generateWorkerWithAI(institutionName, job));
       } else {
         workerPromises.push(Promise.resolve(randomWorker()));
       }
@@ -212,8 +212,9 @@ module.exports = function(institutionStore, userStore, engine, broadcast, sendTo
 
       const institutionName = institution ? institution.name : 'Mars Colony';
       const num = Math.floor(Math.random() * 5) + 1; // 1-5 workers
+      const job = { title: req.body && req.body.title, description: req.body && req.body.description };
 
-      const workers = await generateWorkers(num, institutionName);
+      const workers = await generateWorkers(num, institutionName, job);
       console.log('Workers generated:', workers);
 
       res.json({ workers });

--- a/index.html
+++ b/index.html
@@ -61,6 +61,10 @@
       <div id="popup-workforce-carousel" ></div>
     </div>
     <div id="popup-workforce" class="hidden">
+      <div id="job-posting">
+        <input id="job-title-input" type="text" placeholder="Job Title" />
+        <input id="job-desc-input" type="text" placeholder="Job Description" />
+      </div>
       <div id="workforce-container" ></div>
     </div>
     <div id="popup-chat" class="hidden">
@@ -3135,7 +3139,15 @@ async function showWorkforce() {
 
     try {
       console.log('Requesting applicants from', `/api/workforce/generate/${id}`);
-      const res = await fetch(`/api/workforce/generate/${id}`, { method: 'POST' });
+      const title = document.getElementById('job-title-input').value.trim();
+      const desc = document.getElementById('job-desc-input').value.trim();
+      const body = title || desc ? JSON.stringify({ title, description: desc }) : null;
+      const options = { method: 'POST' };
+      if (body) {
+        options.headers = { 'Content-Type': 'application/json' };
+        options.body = body;
+      }
+      const res = await fetch(`/api/workforce/generate/${id}`, options);
       console.log('Generate response status', res.status);
       if (!res.ok) {
         throw new Error(`HTTP error! status: ${res.status}`);

--- a/style.css
+++ b/style.css
@@ -210,6 +210,17 @@ canvas { display: block; width: 100%; height: 100%; }
   min-width: 100px;
 }
 
+#job-posting {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+#job-posting input {
+  flex: 1;
+  padding: 4px;
+}
+
 #popup-chat {
   /* display will be controlled via the `hidden` class */
 }


### PR DESCRIPTION
## Summary
- allow specifying job title and description before generating applicants
- send optional posting details to backend to tailor AI generation
- style job posting inputs

## Testing
- `npm test` *(fails: Missing script)*
- `node --check api/workforce.js`
- `node server.js` *(fails: username is required)*

------
https://chatgpt.com/codex/tasks/task_e_68482e13316c8329b3f271272e553225