### PR TITLE
Fix resource tracking for proposal effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,6 +621,13 @@ const icons = {
         ['hydration', 'oxygen', 'health', 'money'].forEach(k => {
           if (typeof inst[k] === 'number') effects[k] = inst[k];
         });
+        if (instData.extraEffects) {
+          for (const [k, v] of Object.entries(instData.extraEffects)) {
+            if (typeof v === 'number') {
+              effects[k] = (effects[k] || 0) + v;
+            }
+          }
+        }
         resourceTracking.updateInstitution(
           inst.id,
           instData.name,


### PR DESCRIPTION
## Summary
- include institution `extraEffects` when updating resource tracking
- ensure resource info popup adds extra effects to the displayed totals

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68483698341c8329a1188d5eedbfa0fb